### PR TITLE
Fix remove calculations

### DIFF
--- a/src/checks/zcl_aoc_check_59.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_59.clas.testclasses.abap
@@ -26,7 +26,9 @@ CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
       test002_06 FOR TESTING,
       test002_07 FOR TESTING,
       test003_01 FOR TESTING,
-      test003_02 FOR TESTING.
+      test003_02 FOR TESTING,
+      test004_01 FOR TESTING,
+      test004_02 FOR TESTING.
 
 ENDCLASS.       "lcl_Test
 
@@ -173,6 +175,26 @@ CLASS ltcl_test IMPLEMENTATION.
   METHOD test003_02.
 
     _code 'IF ( foo = bar AND moo = boo ) OR baa = laa.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test004_01.
+
+    _code 'IF SY-DATUM + 1 > + SY-DATUM.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test004_02.
+
+    _code 'IF SY-DATUM + 1 > - SY-DATUM.'.
 
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 

--- a/src/parsing/zcl_aoc_boolean.clas.abap
+++ b/src/parsing/zcl_aoc_boolean.clas.abap
@@ -254,7 +254,29 @@ CLASS ZCL_AOC_BOOLEAN IMPLEMENTATION.
 
         CASE ls_token-str.
           WHEN '+' OR '-' OR '*' OR '/' OR 'MOD' OR 'DIV' OR 'BIT-AND' OR 'BIT-OR' OR '&&'.
-            IF ls_next-str <> '('.
+            IF ls_next-str <> '('
+              AND ls_prev-str <> '='
+              AND ls_prev-str <> '<>'
+              AND ls_prev-str <> '<'
+              AND ls_prev-str <> 'GT'
+              AND ls_prev-str <> '>'
+              AND ls_prev-str <> 'LT'
+              AND ls_prev-str <> '>='
+              AND ls_prev-str <> 'GE'
+              AND ls_prev-str <> 'NS'
+              AND ls_prev-str <> '<='
+              AND ls_prev-str <> 'LE'
+              AND ls_prev-str <> 'NE'
+              AND ls_prev-str <> 'NA'
+              AND ls_prev-str <> 'CO'
+              AND ls_prev-str <> 'CA'
+              AND ls_prev-str <> 'CS'
+              AND ls_prev-str <> 'CN'
+              AND ls_prev-str <> 'IN'
+              AND ls_prev-str <> 'CP'
+              AND ls_prev-str <> 'NP'
+              AND ls_prev-str <> 'IS'
+              AND ls_prev-str <> 'EQ'.
               DO 2 TIMES.
                 DELETE lt_tokens INDEX lv_index.
               ENDDO.

--- a/src/parsing/zcl_aoc_boolean.clas.testclasses.abap
+++ b/src/parsing/zcl_aoc_boolean.clas.testclasses.abap
@@ -83,7 +83,8 @@ CLASS ltcl_parse DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL
       test043 FOR TESTING,
       test044 FOR TESTING,
       test045 FOR TESTING,
-      test046 FOR TESTING.
+      test046 FOR TESTING,
+      test047 FOR TESTING.
 
 ENDCLASS.       "ltcl_Test
 
@@ -564,6 +565,16 @@ CLASS ltcl_parse IMPLEMENTATION.
       exp = 'COMPARE' ).
   ENDMETHOD.
 
+  METHOD test047.
+    DATA: lv_result TYPE string.
+
+    lv_result = parse( 'IF SY-DATUM + 1 > + SY-DATUM.' ).
+
+    cl_abap_unit_assert=>assert_equals(
+      act = lv_result
+      exp = 'COMPARE' ).
+  ENDMETHOD.
+
 ENDCLASS.
 
 CLASS ltcl_remove_strings DEFINITION DEFERRED.
@@ -835,7 +846,8 @@ CLASS ltcl_remove_calculations DEFINITION FOR TESTING DURATION SHORT RISK LEVEL 
       test01 FOR TESTING,
       test02 FOR TESTING,
       test03 FOR TESTING,
-      test04 FOR TESTING.
+      test04 FOR TESTING,
+      test05 FOR TESTING.
 
 ENDCLASS.
 
@@ -878,6 +890,11 @@ CLASS ltcl_remove_calculations IMPLEMENTATION.
   METHOD test04.
     test( iv_code = 'bar * ( moo + 1 )'
           iv_exp  = 'bar' ).
+  ENDMETHOD.
+
+  METHOD test05.
+    test( iv_code = 'IF SY-DATUM + 1 > + SY-DATUM'
+          iv_exp  = 'IF SY-DATUM > + SY-DATUM' ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
The Parser failed at this valid code and gave false positive with `ZCL_AOC_CHECK_58`

```abap
report y_test.

class lcl_program definition.
  public section.
    class-methods:
      main.
endclass.

class lcl_program implementation.
  method main.
    if sy-datum + 1 > + sy-datum.
      write: 'Okay'.
    endif.
  endmethod.
endclass.

start-of-selection.
  lcl_program=>main( ).
```

In this example you have to use ` ... > + sy-datum`.
Otherweise you will get this syntax error message:
`An arithmetic expression cannot be compared with the non-numerical operand "SY-DATUM". However, "+ SY-DATUM" can be used`

I don't know if this is the correct way to fix this problem. I check if the previous token is an comparator before removing the tokens.