### PR TITLE
New check:Message where we use only SY variables

### DIFF
--- a/src/checks/zcl_aoc_check_34.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_34.clas.testclasses.abap
@@ -20,7 +20,9 @@ CLASS ltcl_test DEFINITION FOR TESTING
       export_import FOR TESTING,
       test001_01 FOR TESTING,
       test001_02 FOR TESTING,
-      test001_03 FOR TESTING.
+      test001_03 FOR TESTING,
+      test001_04 FOR TESTING RAISING cx_static_check,
+      test001_05 FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.       "lcl_Test
 
@@ -103,6 +105,143 @@ CLASS ltcl_test IMPLEMENTATION.
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 
     cl_abap_unit_assert=>assert_initial( ms_result ).
+
+  ENDMETHOD.
+
+  METHOD test001_04.
+* ===========
+
+    DATA:
+      lv_attributes    TYPE xstring,
+      lv_incl_comments TYPE flag,
+      lv_lines         TYPE i,
+      lv_errty         TYPE sci_errty.
+
+    lv_attributes = mo_check->get_attributes( ).
+
+    IMPORT
+      mv_errty            = lv_errty
+      mv_lines            = lv_lines
+      mv_incl_comments = lv_incl_comments
+      FROM DATA BUFFER lv_attributes.                "#EC CI_USE_WANTED
+    lv_lines = 20.
+    EXPORT
+      mv_errty            = lv_errty
+      mv_lines            = lv_lines
+      mv_incl_comments    = abap_false
+      TO DATA BUFFER lv_attributes.
+
+    mo_check->put_attributes( lv_attributes ).
+
+    _code 'CASE lv_foo.'.
+    _code '  WHEN ''bar''.'.
+    _code ' ".'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code 'ENDCASE.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+
+
+  ENDMETHOD.
+
+  METHOD test001_05.
+* ===========
+
+    DATA:
+      lv_attributes    TYPE xstring,
+      lv_incl_comments TYPE flag,
+      lv_lines         TYPE i,
+      lv_errty         TYPE sci_errty.
+
+    lv_attributes = mo_check->get_attributes( ).
+
+    IMPORT
+      mv_errty            = lv_errty
+      mv_lines            = lv_lines
+      mv_incl_comments    = lv_incl_comments
+      FROM DATA BUFFER lv_attributes.                "#EC CI_USE_WANTED
+
+    lv_lines = 20.
+
+    EXPORT
+      mv_errty            = lv_errty
+      mv_lines            = lv_lines
+      mv_incl_comments    = abap_true
+      TO DATA BUFFER lv_attributes.
+
+    mo_check->put_attributes( lv_attributes ).
+
+    _code 'CASE lv_foo.'.
+    _code '  WHEN ''bar''.'.
+    _code ' ".'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '*.'.
+    _code '".'.
+    _code ' * .'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code '*.'.
+    _code '".'.
+    _code 'ENDCASE.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_not_initial( ms_result ).
 
   ENDMETHOD.
 

--- a/src/checks/zcl_aoc_check_71.clas.abap
+++ b/src/checks/zcl_aoc_check_71.clas.abap
@@ -1,0 +1,149 @@
+class ZCL_AOC_CHECK_71 definition
+  public
+  inheriting from ZCL_AOC_SUPER
+  create public .
+
+public section.
+
+  methods CONSTRUCTOR .
+
+  methods CHECK
+    redefinition .
+  methods GET_ATTRIBUTES
+    redefinition .
+  methods GET_MESSAGE_TEXT
+    redefinition .
+  methods IF_CI_TEST~QUERY_ATTRIBUTES
+    redefinition .
+  methods PUT_ATTRIBUTES
+    redefinition .
+  protected section.
+
+    data mv_unreachable type sap_bool.
+  private section.
+ENDCLASS.
+
+
+
+CLASS ZCL_AOC_CHECK_71 IMPLEMENTATION.
+
+
+  method check.
+
+* abapOpenChecks
+* https://github.com/larshp/abapOpenChecks
+* MIT License
+
+    data: lt_statements type ty_statements,
+          lv_index      type i,
+          lv_code       type sci_errc,
+          ls_prev       like line of lt_statements.
+
+    field-symbols: <ls_statement> like line of lt_statements.
+
+    lt_statements = build_statements(
+      it_tokens     = it_tokens
+      it_statements = it_statements
+      it_levels     = it_levels ).
+
+    loop at lt_statements assigning <ls_statement>.
+      lv_index = sy-tabix - 1.
+      clear ls_prev.
+      read table lt_statements index lv_index into ls_prev. "#EC CI_SUBRC
+
+      find regex 'MESSAGE.ID.SY-MSGID.TYPE.SY-MSGTY.NUMBER.SY-MSGNO.WITH.SY-MSGV.' in <ls_statement>-str.
+      if sy-subrc ne 0.
+        continue.
+      endif.
+
+      if <ls_statement>-str cp 'MESSAGE *'
+          and ( ( mv_unreachable = abap_true and ls_prev-str = 'IF 1 = 2' )
+          or ( mv_unreachable = abap_true and ls_prev-str = 'IF 0 = 1' ) ).
+        continue.
+      endif.
+
+      if <ls_statement>-str cp 'MESSAGE *'.
+        lv_code = '001'.
+      else.
+        assert 0 = 1.
+      endif.
+
+      inform( p_sub_obj_type = c_type_include
+              p_sub_obj_name = <ls_statement>-include
+              p_line         = <ls_statement>-start-row
+              p_kind         = mv_errty
+              p_test         = myname
+              p_code         = lv_code ).
+    endloop.
+
+  endmethod.
+
+
+  method constructor.
+
+    super->constructor( ).
+
+    description = 'MESSAGE using sytem variables SY-MSGTY, SY-MSGNO, etc'. "#EC NOTEXT
+    category    = 'ZCL_AOC_CATEGORY'.
+    version     = '001'.
+    position    = '071'.
+
+    has_attributes = abap_true.
+    attributes_ok  = abap_true.
+
+    enable_rfc( ).
+
+    mv_errty   = c_error.
+    mv_unreachable = abap_true.
+
+  endmethod.                    "CONSTRUCTOR
+
+
+  method get_attributes.
+
+    export
+      mv_errty = mv_errty
+      mv_unreachable = mv_unreachable
+      to data buffer p_attributes.
+
+  endmethod.
+
+
+  method get_message_text.
+
+    clear p_text.
+
+    case p_code.
+      when '001'.
+        p_text = 'MESSAGE using standard variables from SY structure'.                 "#EC NOTEXT
+      when others.
+        super->get_message_text( exporting p_test = p_test
+                                           p_code = p_code
+                                 importing p_text = p_text ).
+    endcase.
+
+  endmethod.
+
+
+  method if_ci_test~query_attributes.
+
+    zzaoc_top.
+
+    zzaoc_fill_att mv_errty 'Error Type' ''.                "#EC NOTEXT
+    zzaoc_fill_att mv_unreachable 'Allow unreachable' 'C'.  "#EC NOTEXT
+
+    zzaoc_popup.
+
+  endmethod.
+
+
+  method put_attributes.
+
+    import
+      mv_errty = mv_errty
+      mv_unreachable = mv_unreachable
+      from data buffer p_attributes.                 "#EC CI_USE_WANTED
+    assert sy-subrc = 0.
+
+  endmethod.
+ENDCLASS.

--- a/src/checks/zcl_aoc_check_71.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_71.clas.testclasses.abap
@@ -1,0 +1,96 @@
+*----------------------------------------------------------------------*
+*       CLASS lcl_Test DEFINITION
+*----------------------------------------------------------------------*
+*
+*----------------------------------------------------------------------*
+CLASS ltcl_test DEFINITION FOR TESTING DURATION SHORT RISK LEVEL HARMLESS FINAL.
+
+  PRIVATE SECTION.
+* ================
+
+    DATA: mt_code   TYPE string_table,
+          ms_result TYPE scirest_ad,
+          mo_check  TYPE REF TO ZCL_AOC_CHECK_71.
+
+    METHODS:
+      setup,
+      export_import FOR TESTING,
+      test001_01 FOR TESTING,
+      test001_02 FOR TESTING,
+      test001_03 FOR TESTING,
+      test001_04 FOR TESTING.
+
+ENDCLASS.       "lcl_Test
+
+*----------------------------------------------------------------------*
+*       CLASS lcl_Test IMPLEMENTATION
+*----------------------------------------------------------------------*
+*
+*----------------------------------------------------------------------*
+CLASS ltcl_test IMPLEMENTATION.
+* ==============================
+
+  DEFINE _code.
+    APPEND &1 TO mt_code.
+  END-OF-DEFINITION.
+
+  METHOD setup.
+    CREATE OBJECT mo_check.
+    zcl_aoc_unit_test=>set_check( mo_check ).
+    zcl_aoc_unit_test=>set_object_type( 'CLAS' ).
+  ENDMETHOD.                    "setup
+
+  METHOD export_import.
+    zcl_aoc_unit_test=>export_import( mo_check ).
+  ENDMETHOD.
+
+  METHOD test001_01.
+* ===========
+
+    _code ' message id sy-msgid type sy-msgty number sy-msgno with sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_equals( exp = '001'
+                                        act = ms_result-code ).
+
+  ENDMETHOD.                    "test1
+
+  METHOD test001_02.
+* ===========
+
+    _code 'CALL TRANSACTION ''VA01''.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test001_03.
+* ===========
+
+    _code ` message id sy-msgid type 'S' number sy-msgno with sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4.`.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test001_04.
+* ===========
+
+    _code 'IF 1 = 2.'.
+    _code '  message id sy-msgid type sy-msgty number sy-msgno with sy-msgv1 sy-msgv2 sy-msgv3 sy-msgv4.'.
+    _code 'ENDIF.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.                    "test1
+
+
+
+ENDCLASS.       "lcl_Test

--- a/src/checks/zcl_aoc_check_71.clas.xml
+++ b/src/checks/zcl_aoc_check_71.clas.xml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_AOC_CHECK_71</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>MESSAGE using sytem variables SY-MSGTY, SY-MSGNO, etc</DESCRIPT>
+    <EXPOSURE>2</EXPOSURE>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <RSTAT>P</RSTAT>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+   <LINES>
+    <TLINE>
+     <TDFORMAT>*</TDFORMAT>
+     <TDLINE>abapOpenChecks</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>*</TDFORMAT>
+     <TDLINE>https://github.com/larshp/abapOpenChecks</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>*</TDFORMAT>
+     <TDLINE>MIT License</TDLINE>
+    </TLINE>
+   </LINES>
+  </asx:values>
+ </asx:abap>
+</abapGit>


### PR DESCRIPTION
We have in company many dumps when developers uses the message handling that is prompted by eclipse as the raising clause is not always passed with the message.