### PR TITLE
Correction to CHECK_56

### DIFF
--- a/src/checks/zcl_aoc_check_56.clas.abap
+++ b/src/checks/zcl_aoc_check_56.clas.abap
@@ -94,7 +94,9 @@ CLASS ZCL_AOC_CHECK_56 IMPLEMENTATION.
           lv_include    TYPE programm,
           lt_parameters TYPE ty_vseosubcdf_tt.
     
-    CHECK mv_referenced EQ abap_true.
+    IF mv_referenced EQ abap_false.
+       RETURN.
+    ENDIF.
 
     SELECT * FROM vseosubcdf INTO TABLE lt_parameters
       WHERE clsname = is_method-clsname
@@ -171,7 +173,9 @@ CLASS ZCL_AOC_CHECK_56 IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_parameter> LIKE LINE OF lt_parameters,
                    <ls_found>     LIKE LINE OF lt_found.
 
-    CHECK mv_supplied EQ abap_true.
+    IF mv_supplied EQ abap_false.
+      RETURN.
+    ENDIF.
 
     SELECT * FROM seosubcodf INTO TABLE lt_parameters
       WHERE clsname = is_method-clsname

--- a/src/checks/zcl_aoc_check_56.clas.abap
+++ b/src/checks/zcl_aoc_check_56.clas.abap
@@ -93,7 +93,8 @@ CLASS ZCL_AOC_CHECK_56 IMPLEMENTATION.
           ls_mtdkey     TYPE seocpdkey,
           lv_include    TYPE programm,
           lt_parameters TYPE ty_vseosubcdf_tt.
-
+    
+    CHECK mv_referenced EQ abap_true.
 
     SELECT * FROM vseosubcdf INTO TABLE lt_parameters
       WHERE clsname = is_method-clsname
@@ -170,6 +171,7 @@ CLASS ZCL_AOC_CHECK_56 IMPLEMENTATION.
     FIELD-SYMBOLS: <ls_parameter> LIKE LINE OF lt_parameters,
                    <ls_found>     LIKE LINE OF lt_found.
 
+    CHECK mv_supplied EQ abap_true.
 
     SELECT * FROM seosubcodf INTO TABLE lt_parameters
       WHERE clsname = is_method-clsname


### PR DESCRIPTION
This check has two parameters in customizing but it was not using it at all. I've added two lines to respect the parameters.