### PR TITLE
Check 56 omits MESSAGE statement

### DIFF
--- a/src/checks/zcl_aoc_check_56.clas.abap
+++ b/src/checks/zcl_aoc_check_56.clas.abap
@@ -142,6 +142,7 @@ CLASS ZCL_AOC_CHECK_56 IMPLEMENTATION.
         name = ls_compiler-name.
       ENDIF.
       DELETE lt_parameters WHERE sconame = name.
+      CLEAR name.
     ENDLOOP.
 
     IF lines( lt_parameters ) > 0.


### PR DESCRIPTION
When method parameters were referenced in MESSAGE statement then it was consider as not referenced.
Additionally sometimes compiler return wrong name of parameter, for example instead of I_NUMBER -> _NUMBER so the deletion of not referenced parameters doesn't work. I've used regex on FULL_NAME instead direct reading of ls_compiler-NAME.