### PR TITLE
Check 27 - Last statement is obsolet - clear is okay if it is the parameter in a form

### DIFF
--- a/src/checks/zcl_aoc_check_27.clas.abap
+++ b/src/checks/zcl_aoc_check_27.clas.abap
@@ -288,7 +288,8 @@ CLASS ZCL_AOC_CHECK_27 IMPLEMENTATION.
           LOOP AT mt_statements ASSIGNING <ls_statement> WHERE
             ( row < <ls_result>-line AND row_to > <ls_result>-line ) OR
             ( row = <ls_result>-line AND col <= <ls_result>-column AND row_to > <ls_result>-line ) OR
-            ( row = <ls_result>-line AND col <= <ls_result>-column AND row_to = <ls_result>-line AND col_to >= <ls_result>-column ) OR
+            ( row = <ls_result>-line AND col <= <ls_result>-column AND
+              row_to = <ls_result>-line AND col_to >= <ls_result>-column ) OR
             ( row < <ls_result>-line AND row_to = <ls_result>-line AND col_to >= <ls_result>-column ).
             IF <ls_statement>-statement CP 'FORM *'.
               RETURN.

--- a/src/checks/zcl_aoc_check_27.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_27.clas.testclasses.abap
@@ -25,6 +25,7 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test001_05 FOR TESTING,
       test001_06 FOR TESTING,
       test001_07 FOR TESTING,
+      test002_01 FOR TESTING,
       test003_01 FOR TESTING.
 
 ENDCLASS.       "lcl_Test
@@ -153,6 +154,19 @@ CLASS ltcl_test IMPLEMENTATION.
                                         act = ms_result-code ).
 
   ENDMETHOD.
+
+  METHOD test002_01.
+* ===========
+
+    _code 'FORM foo USING pv_foo.'.
+    _code '  CLEAR pv_foo.'.
+    _code 'ENDFORM.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+
+  ENDMETHOD.                    "test2
 
   METHOD test003_01.
 * ===========


### PR DESCRIPTION
It's not the nicest approach i could think of, but at least it fixes the false positive.

fix #308