### PR TITLE
New Check: Activate fixed point arithmetic

### DIFF
--- a/docs/_checks/85.md
+++ b/docs/_checks/85.md
@@ -1,0 +1,8 @@
+---
+title: Activate fixed point arithmetic
+cNumber: CHECK_85
+rfc: false
+---
+
+### Activate fixed point arithmetic
+Activate fixed point arithmetic

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -14,6 +14,13 @@ public section.
 protected section.
 private section.
 
+  methods CHECK_COMPUTE
+    importing
+      !IT_TOKENS type STOKESX_TAB
+      !IS_STATEMENT type SSTMNT
+      !IO_COMPILER type ref to CL_ABAP_COMPILER
+    changing
+      value(CV_SAVE_TO_CHANGE) type ABAP_BOOL .
   methods GET_STATEMENT
     importing
       !IT_TOKENS type STOKESX_TAB
@@ -34,29 +41,20 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
 * MIT License
 
     DATA:
-      lv_stmt_index      TYPE i,
-      lo_compiler        TYPE REF TO cl_abap_compiler,
-      lv_save_to_change  TYPE abap_bool,
-      lv_used_define     TYPE abap_bool,
-      lv_inform          TYPE abap_bool,
-      lv_define          TYPE abap_bool,
-      lv_keyword         TYPE string,
-      lv_full            TYPE string,
-      lo_data_assignment TYPE REF TO cl_abap_comp_data,
-      lo_data            TYPE REF TO cl_abap_comp_data,
-      lt_data            TYPE STANDARD TABLE OF REF TO cl_abap_comp_data,
-      lv_statement       TYPE string.
+      lo_compiler       TYPE REF TO cl_abap_compiler,
+      lv_save_to_change TYPE abap_bool,
+      lv_used_define    TYPE abap_bool,
+      lv_define         TYPE abap_bool,
+      lv_keyword        TYPE string.
 
-    FIELD-SYMBOLS:
-      <ls_token> LIKE LINE OF it_tokens.
-
-    CHECK trdir-fixpt = abap_false.
+    IF trdir-fixpt = abap_false.
+      RETURN.
+    ENDIF.
     lv_save_to_change = abap_true.
 
     lo_compiler = cl_abap_compiler=>create( program_name ).
 
     LOOP AT it_statements INTO statement_wa.
-      lv_stmt_index = sy-tabix.
       lv_keyword = keyword( ).
       IF lv_define = abap_true.
         IF lv_keyword = 'END-OF-DEFINITION'.
@@ -70,90 +68,13 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
           lv_save_to_change = abap_false. "define is black magic
           lv_define = abap_true.
         WHEN 'COMPUTE'.
-          CLEAR: lt_data, lo_data, lo_data_assignment.
-          lv_inform = abap_false.
-
-          "concate statement for debugging purpose and inform
-          lv_statement = get_statement(
-            it_tokens     = it_tokens
-            is_statement  = statement_wa
-          ).
-
-          "check for multiplication and division
-          LOOP AT it_tokens ASSIGNING <ls_token> FROM statement_wa-from TO statement_wa-to
-              WHERE str = '*'
-                 OR str = '/'.
-            lv_inform = abap_true.
-            EXIT.
-          ENDLOOP.
-
-          IF lv_inform = abap_false.
-            "collect all types of compute statmenet
-            LOOP AT it_tokens ASSIGNING <ls_token> FROM statement_wa-from TO statement_wa-to
-                WHERE str <> '='.
-              lo_compiler->get_full_name_for_position(
-                EXPORTING
-                  p_line   =  <ls_token>-row
-                  p_column = CONV i( <ls_token>-col )
-                  p_include = get_include( p_level = statement_wa-level )
-                IMPORTING
-                  p_full_name = lv_full
-                EXCEPTIONS
-                  OTHERS = 4
-              ).
-              IF sy-subrc = 0.
-                lo_data ?= lo_compiler->get_symbol_entry( lv_full ).
-                APPEND lo_data TO lt_data.
-              ENDIF.
-            ENDLOOP.
-
-            "check type compatibility
-            READ TABLE lt_data INTO lo_data_assignment INDEX 1.
-            IF sy-subrc = 0.
-*              IF lo_data_assignment->type->full_name = '\PT:SIMPLE'.
-              IF lo_data_assignment->type->length = -1.
-                "it's a parameter
-                lv_inform = abap_true.
-              ELSEIF lo_data_assignment->type->atyp = 'P'.
-                LOOP AT lt_data FROM 2 INTO lo_data.
-                  "packed number
-                  IF lo_data->type->atyp = 'P'.
-                    IF lo_data->type->decimals <> lo_data_assignment->type->decimals.
-                      lv_inform = abap_true.
-                      EXIT.
-                    ENDIF.
-                  ENDIF.
-                  "integer or char or string
-                  IF lo_data->type->atyp = 'I' OR lo_data->type->atyp = 'C' OR lo_data->type->atyp = 'g'.
-                    lv_inform = abap_true.
-                    EXIT.
-                  ENDIF.
-                ENDLOOP.
-                IF sy-subrc <> 0.
-                  "some strange assignment, e.g. string template
-                  lv_inform = abap_true.
-                ENDIF.
-              ENDIF.
-            ENDIF.
-          ENDIF.
-
-          IF lv_inform = abap_true.
-            lv_save_to_change = abap_false.
-            "get token for line/col
-            LOOP AT it_tokens ASSIGNING <ls_token> FROM statement_wa-from TO statement_wa-to.
-              EXIT.
-            ENDLOOP.
-
-            inform(
-              p_sub_obj_type = c_type_include
-              p_sub_obj_name = get_include( p_level = statement_wa-level )
-              p_line         = <ls_token>-row
-              p_column       = <ls_token>-col
-              p_kind         = 'N'
-              p_test         = myname
-              p_code         = '002'
-              p_param_1      = lv_statement ).
-          ENDIF.
+          check_compute(
+            EXPORTING
+              it_tokens    = it_tokens
+              is_statement = statement_wa
+              io_compiler  = lo_compiler
+            CHANGING
+              cv_save_to_change = lv_save_to_change ).
       ENDCASE.
     ENDLOOP.
 
@@ -170,7 +91,99 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD CONSTRUCTOR.
+  METHOD check_compute.
+    DATA:
+      lv_statement       TYPE string,
+      lv_inform          TYPE abap_bool,
+      lv_full            TYPE string,
+      lt_data            TYPE STANDARD TABLE OF REF TO cl_abap_comp_data,
+      lo_data            TYPE REF TO cl_abap_comp_data,
+      lo_data_assignment TYPE REF TO cl_abap_comp_data.
+
+    FIELD-SYMBOLS:
+      <ls_token> LIKE LINE OF it_tokens.
+
+    "concate statement for debugging purpose and inform
+    lv_statement = get_statement(
+      it_tokens     = it_tokens
+      is_statement  = is_statement ).
+
+    "check for multiplication and division
+    LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to
+        WHERE str = '*'
+           OR str = '/'.
+      lv_inform = abap_true.
+      EXIT.
+    ENDLOOP.
+
+    IF lv_inform = abap_false.
+      "collect all types of compute statmenet
+      LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to
+          WHERE str <> '='.
+        io_compiler->get_full_name_for_position(
+          EXPORTING
+            p_line   =  <ls_token>-row
+            p_column = CONV i( <ls_token>-col )
+            p_include = get_include( p_level = is_statement-level )
+          IMPORTING
+            p_full_name = lv_full
+          EXCEPTIONS
+            OTHERS = 4 ).
+        IF sy-subrc = 0.
+          lo_data ?= io_compiler->get_symbol_entry( lv_full ).
+          APPEND lo_data TO lt_data.
+        ENDIF.
+      ENDLOOP.
+
+      "check type compatibility
+      READ TABLE lt_data INTO lo_data_assignment INDEX 1.
+      IF sy-subrc = 0.
+        IF lo_data_assignment->type->length = -1.
+          "it's a parameter
+          lv_inform = abap_true.
+        ELSEIF lo_data_assignment->type->atyp = 'P'.
+          LOOP AT lt_data FROM 2 INTO lo_data.
+            IF lo_data->type->atyp = 'P'.
+              "packed number
+              IF lo_data->type->decimals <> lo_data_assignment->type->decimals.
+                lv_inform = abap_true.
+                EXIT.
+              ENDIF.
+            ELSEIF lo_data->type->atyp = 'I' OR lo_data->type->atyp = 'C' OR lo_data->type->atyp = 'g'.
+              "integer or char or string
+              lv_inform = abap_true.
+              EXIT.
+            ENDIF.
+          ENDLOOP.
+          IF sy-subrc <> 0.
+            "some strange assignment, e.g. string template
+            lv_inform = abap_true.
+          ENDIF.
+        ENDIF.
+      ENDIF.
+    ENDIF.
+
+    IF lv_inform = abap_true.
+      cv_save_to_change = abap_false.
+      "get token for line/col
+      LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to.
+        EXIT.
+      ENDLOOP.
+
+      inform(
+        p_sub_obj_type = c_type_include
+        p_sub_obj_name = get_include( p_level = is_statement-level )
+        p_line         = <ls_token>-row
+        p_column       = <ls_token>-col
+        p_kind         = 'N'
+        p_test         = myname
+        p_code         = '002'
+        p_param_1      = lv_statement ).
+    ENDIF.
+  ENDMETHOD.
+
+
+  METHOD constructor.
 
     super->constructor( ).
 
@@ -179,8 +192,6 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
 
     has_attributes = abap_true.
     attributes_ok  = abap_true.
-
-*    enable_rfc( ).
 
     mv_errty = 'E'.
   ENDMETHOD.                    "CONSTRUCTOR

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -121,7 +121,7 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
       "collect all types of compute statement
       LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to
           WHERE str <> '='.
-        lv_column = <ls_token>-col.
+        lv_column = <ls_token>-col + <ls_token>-len1 - 1. "end of token
         io_compiler->get_full_name_for_position(
           EXPORTING
             p_line    = <ls_token>-row
@@ -132,8 +132,12 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
           EXCEPTIONS
             OTHERS = 4 ).
         IF sy-subrc = 0.
-          lo_data ?= io_compiler->get_symbol_entry( lv_full ).
-          APPEND lo_data TO lt_data.
+          TRY.
+              lo_data ?= io_compiler->get_symbol_entry( lv_full ).
+              APPEND lo_data TO lt_data.
+            CATCH cx_sy_move_cast_error.
+              "ignore - only take simple types
+          ENDTRY.
         ENDIF.
       ENDLOOP.
 

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -95,6 +95,7 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
     DATA:
       lv_statement       TYPE string,
       lv_inform          TYPE abap_bool,
+      lv_column          TYPE i,
       lv_full            TYPE string,
       lt_data            TYPE STANDARD TABLE OF REF TO cl_abap_comp_data,
       lo_data            TYPE REF TO cl_abap_comp_data,
@@ -120,10 +121,11 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
       "collect all types of compute statmenet
       LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to
           WHERE str <> '='.
+        lv_column = <ls_token>-col.
         io_compiler->get_full_name_for_position(
           EXPORTING
-            p_line   =  <ls_token>-row
-            p_column = CONV i( <ls_token>-col )
+            p_line    = <ls_token>-row
+            p_column  = lv_column
             p_include = get_include( p_level = is_statement-level )
           IMPORTING
             p_full_name = lv_full

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -1,32 +1,32 @@
-class ZCL_AOC_CHECK_85 definition
-  public
-  inheriting from ZCL_AOC_SUPER
-  create public .
+CLASS zcl_aoc_check_85 DEFINITION
+  PUBLIC
+  INHERITING FROM zcl_aoc_super
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods CONSTRUCTOR .
+    METHODS constructor .
 
-  methods CHECK
-    redefinition .
-  methods GET_MESSAGE_TEXT
-    redefinition .
-protected section.
-private section.
+    METHODS check
+         REDEFINITION .
+    METHODS get_message_text
+         REDEFINITION .
+  PROTECTED SECTION.
+  PRIVATE SECTION.
 
-  methods CHECK_COMPUTE
-    importing
-      !IT_TOKENS type STOKESX_TAB
-      !IS_STATEMENT type SSTMNT
-      !IO_COMPILER type ref to CL_ABAP_COMPILER
-    changing
-      value(CV_SAVE_TO_CHANGE) type ABAP_BOOL .
-  methods GET_STATEMENT
-    importing
-      !IT_TOKENS type STOKESX_TAB
-      !IS_STATEMENT type SSTMNT
-    returning
-      value(RV_STATEMENT) type STRING .
+    METHODS check_compute
+      IMPORTING
+        !it_tokens               TYPE stokesx_tab
+        !is_statement            TYPE sstmnt
+        !io_compiler             TYPE REF TO cl_abap_compiler
+      CHANGING
+        VALUE(cv_save_to_change) TYPE abap_bool .
+    METHODS get_statement
+      IMPORTING
+        !it_tokens          TYPE stokesx_tab
+        !is_statement       TYPE sstmnt
+      RETURNING
+        VALUE(rv_statement) TYPE string .
 ENDCLASS.
 
 

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -118,7 +118,7 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
     ENDLOOP.
 
     IF lv_inform = abap_false.
-      "collect all types of compute statmenet
+      "collect all types of compute statement
       LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to
           WHERE str <> '='.
         lv_column = <ls_token>-col.

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -1,0 +1,219 @@
+class ZCL_AOC_CHECK_85 definition
+  public
+  inheriting from ZCL_AOC_SUPER
+  create public .
+
+public section.
+
+  methods CONSTRUCTOR .
+
+  methods CHECK
+    redefinition .
+  methods GET_MESSAGE_TEXT
+    redefinition .
+protected section.
+private section.
+
+  methods GET_STATEMENT
+    importing
+      !IT_TOKENS type STOKESX_TAB
+      !IS_STATEMENT type SSTMNT
+    returning
+      value(RV_STATEMENT) type STRING .
+ENDCLASS.
+
+
+
+CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
+
+
+  METHOD check.
+
+* abapOpenChecks
+* https://github.com/larshp/abapOpenChecks
+* MIT License
+
+    DATA:
+      lv_stmt_index      TYPE i,
+      lo_compiler        TYPE REF TO cl_abap_compiler,
+      lv_save_to_change  TYPE abap_bool,
+      lv_used_define     TYPE abap_bool,
+      lv_inform          TYPE abap_bool,
+      lv_define          TYPE abap_bool,
+      lv_keyword         TYPE string,
+      lv_full            TYPE string,
+      lo_data_assignment TYPE REF TO cl_abap_comp_data,
+      lo_data            TYPE REF TO cl_abap_comp_data,
+      lt_data            TYPE STANDARD TABLE OF REF TO cl_abap_comp_data,
+      lv_statement       TYPE string.
+
+    FIELD-SYMBOLS:
+      <ls_token> LIKE LINE OF it_tokens.
+
+    CHECK trdir-fixpt = abap_false.
+    lv_save_to_change = abap_true.
+
+    lo_compiler = cl_abap_compiler=>create( program_name ).
+
+    LOOP AT it_statements INTO statement_wa.
+      lv_stmt_index = sy-tabix.
+      lv_keyword = keyword( ).
+      IF lv_define = abap_true.
+        IF lv_keyword = 'END-OF-DEFINITION'.
+          lv_define = abap_false.
+        ENDIF.
+        CONTINUE.
+      ENDIF.
+
+      CASE lv_keyword.
+        WHEN 'DEFINE'.
+          lv_save_to_change = abap_false. "define is black magic
+          lv_define = abap_true.
+        WHEN 'COMPUTE'.
+          CLEAR: lt_data, lo_data, lo_data_assignment.
+          lv_inform = abap_false.
+
+          "concate statement for debugging purpose and inform
+          lv_statement = get_statement(
+            it_tokens     = it_tokens
+            is_statement  = statement_wa
+          ).
+
+          "check for multiplication and division
+          LOOP AT it_tokens ASSIGNING <ls_token> FROM statement_wa-from TO statement_wa-to
+              WHERE str = '*'
+                 OR str = '/'.
+            lv_inform = abap_true.
+            EXIT.
+          ENDLOOP.
+
+          IF lv_inform = abap_false.
+            "collect all types of compute statmenet
+            LOOP AT it_tokens ASSIGNING <ls_token> FROM statement_wa-from TO statement_wa-to
+                WHERE str <> '='.
+              lo_compiler->get_full_name_for_position(
+                EXPORTING
+                  p_line   =  <ls_token>-row
+                  p_column = CONV i( <ls_token>-col )
+                  p_include = get_include( p_level = statement_wa-level )
+                IMPORTING
+                  p_full_name = lv_full
+                EXCEPTIONS
+                  OTHERS = 4
+              ).
+              IF sy-subrc = 0.
+                lo_data ?= lo_compiler->get_symbol_entry( lv_full ).
+                APPEND lo_data TO lt_data.
+              ENDIF.
+            ENDLOOP.
+
+            "check type compatibility
+            READ TABLE lt_data INTO lo_data_assignment INDEX 1.
+            IF sy-subrc = 0.
+*              IF lo_data_assignment->type->full_name = '\PT:SIMPLE'.
+              IF lo_data_assignment->type->length = -1.
+                "it's a parameter
+                lv_inform = abap_true.
+              ELSEIF lo_data_assignment->type->atyp = 'P'.
+                LOOP AT lt_data FROM 2 INTO lo_data.
+                  "packed number
+                  IF lo_data->type->atyp = 'P'.
+                    IF lo_data->type->decimals <> lo_data_assignment->type->decimals.
+                      lv_inform = abap_true.
+                      EXIT.
+                    ENDIF.
+                  ENDIF.
+                  "integer or char or string
+                  IF lo_data->type->atyp = 'I' OR lo_data->type->atyp = 'C' OR lo_data->type->atyp = 'g'.
+                    lv_inform = abap_true.
+                    EXIT.
+                  ENDIF.
+                ENDLOOP.
+                IF sy-subrc <> 0.
+                  "some strange assignment, e.g. string template
+                  lv_inform = abap_true.
+                ENDIF.
+              ENDIF.
+            ENDIF.
+          ENDIF.
+
+          IF lv_inform = abap_true.
+            lv_save_to_change = abap_false.
+            "get token for line/col
+            LOOP AT it_tokens ASSIGNING <ls_token> FROM statement_wa-from TO statement_wa-to.
+              EXIT.
+            ENDLOOP.
+
+            inform(
+              p_sub_obj_type = c_type_include
+              p_sub_obj_name = get_include( p_level = statement_wa-level )
+              p_line         = <ls_token>-row
+              p_column       = <ls_token>-col
+              p_kind         = 'N'
+              p_test         = myname
+              p_code         = '002'
+              p_param_1      = lv_statement ).
+          ENDIF.
+      ENDCASE.
+    ENDLOOP.
+
+    IF lv_save_to_change = abap_true.
+      inform( p_test = myname
+              p_kind = mv_errty
+              p_code = '001' ).
+    ELSEIF lv_used_define = abap_true.
+      inform( p_test = myname
+              p_kind = 'N'
+              p_code = '003' ).
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD CONSTRUCTOR.
+
+    super->constructor( ).
+
+    version     = '001'.
+    position    = '085'.
+
+    has_attributes = abap_true.
+    attributes_ok  = abap_true.
+
+*    enable_rfc( ).
+
+    mv_errty = 'E'.
+  ENDMETHOD.                    "CONSTRUCTOR
+
+
+  METHOD get_message_text.
+
+    CASE p_code.
+      WHEN '001'.
+        p_text = 'Fixed point arithmetic can be safely activated'.
+      WHEN '002'.
+        p_text = 'Statement blocks activation of fixed point arithmetic: &1'.
+      WHEN '003'.
+        p_text = 'Because of the use of DEFINE, it can not be determined if fixed point arithmetic can be activated'.
+      WHEN OTHERS.
+        super->get_message_text( EXPORTING p_test = p_test
+                                           p_code = p_code
+                                 IMPORTING p_text = p_text ).
+    ENDCASE.
+
+  ENDMETHOD.                    "GET_MESSAGE_TEXT
+
+
+  METHOD get_statement.
+    FIELD-SYMBOLS:
+      <ls_token> LIKE LINE OF it_tokens.
+
+    LOOP AT it_tokens ASSIGNING <ls_token> FROM is_statement-from TO is_statement-to.
+      IF rv_statement IS INITIAL.
+        rv_statement = <ls_token>-str.
+      ELSE.
+        CONCATENATE rv_statement <ls_token>-str INTO rv_statement SEPARATED BY space.
+      ENDIF.
+    ENDLOOP.
+  ENDMETHOD.
+ENDCLASS.

--- a/src/checks/zcl_aoc_check_85.clas.abap
+++ b/src/checks/zcl_aoc_check_85.clas.abap
@@ -47,7 +47,7 @@ CLASS ZCL_AOC_CHECK_85 IMPLEMENTATION.
       lv_define         TYPE abap_bool,
       lv_keyword        TYPE string.
 
-    IF trdir-fixpt = abap_false.
+    IF trdir-fixpt = abap_true.
       RETURN.
     ENDIF.
     lv_save_to_change = abap_true.

--- a/src/checks/zcl_aoc_check_85.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_85.clas.testclasses.abap
@@ -1,0 +1,27 @@
+CLASS ltcl_test DEFINITION FOR TESTING
+  DURATION SHORT
+  RISK LEVEL HARMLESS
+  FINAL.
+
+  PRIVATE SECTION.
+    DATA:
+      mo_check  TYPE REF TO zcl_aoc_check_85.
+
+    METHODS:
+      setup,
+      export_import FOR TESTING.
+
+ENDCLASS.
+
+CLASS ltcl_test IMPLEMENTATION.
+
+  METHOD setup.
+    CREATE OBJECT mo_check.
+    zcl_aoc_unit_test=>set_check( mo_check ).
+  ENDMETHOD.
+
+  METHOD export_import.
+    zcl_aoc_unit_test=>export_import( mo_check ).
+  ENDMETHOD.
+
+ENDCLASS.

--- a/src/checks/zcl_aoc_check_85.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_85.clas.testclasses.abap
@@ -1,3 +1,5 @@
+CLASS lcl_temporary_program DEFINITION DEFERRED.
+
 CLASS ltcl_test DEFINITION FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS
@@ -5,23 +7,260 @@ CLASS ltcl_test DEFINITION FOR TESTING
 
   PRIVATE SECTION.
     DATA:
-      mo_check  TYPE REF TO zcl_aoc_check_85.
+      mt_code    TYPE string_table,
+      ms_result  TYPE scirest_ad,
+      mv_text    TYPE string,
+      mo_program TYPE REF TO lcl_temporary_program,
+      mo_check   TYPE REF TO zcl_aoc_check_85.
 
     METHODS:
       setup,
-      export_import FOR TESTING.
+      teardown,
+      message_handler FOR EVENT message OF zcl_aoc_check_85 IMPORTING p_param_1,
+      export_import FOR TESTING,
+      test_1 FOR TESTING,
+      test_1_with_fixpt FOR TESTING,
+      test_2 FOR TESTING,
+      test_3 FOR TESTING,
+      test_4 FOR TESTING,
+      test_5 FOR TESTING,
+      test_6 FOR TESTING,
+      test_7 FOR TESTING,
+      test_8 FOR TESTING.
+
+ENDCLASS.
+
+CLASS lcl_temporary_program DEFINITION FOR TESTING FINAL.
+  PUBLIC SECTION.
+    TYPES:
+      t_program_name TYPE c LENGTH 30.
+    METHODS:
+      constructor,
+      cleanup,
+      get_program_name RETURNING VALUE(rv_program_name) TYPE t_program_name,
+      generate_programm IMPORTING it_source_code TYPE STANDARD TABLE iv_fixpt TYPE fixpt DEFAULT abap_false.
+
+  PRIVATE SECTION.
+    DATA:
+      mv_program_generated TYPE abap_bool,
+      mv_program_name      TYPE t_program_name.
+ENDCLASS.
+
+CLASS lcl_temporary_program IMPLEMENTATION.
+  METHOD constructor.
+    DATA:
+      lt_data TYPE STANDARD TABLE OF rbase.
+    mv_program_name = 'YAOC_CHECK_85_TEST'.
+
+    "find a free program name
+    LOAD REPORT mv_program_name PART 'BASE' INTO lt_data.
+    WHILE sy-subrc <> 4.
+      IF sy-index > 10.
+        CLEAR mv_program_name.
+        cl_abap_unit_assert=>abort( 'Can not find a free program name to generate report for testing'  ).
+        RETURN.
+      ENDIF.
+      mv_program_name = 'YAOC_CHECK_85_TEST' && '_' && sy-index.
+      LOAD REPORT mv_program_name PART 'BASE' INTO lt_data.
+    ENDWHILE.
+
+  ENDMETHOD.
+
+  METHOD get_program_name.
+    rv_program_name = mv_program_name.
+  ENDMETHOD.
+
+  METHOD cleanup.
+    IF mv_program_name IS NOT INITIAL AND mv_program_generated = abap_true.
+      DELETE REPORT mv_program_name.
+      mv_program_generated = abap_false.
+    ENDIF.
+  ENDMETHOD.
+
+  METHOD generate_programm.
+    IF mv_program_name IS NOT INITIAL.
+      INSERT REPORT mv_program_name
+        FROM it_source_code
+        FIXED-POINT ARITHMETIC iv_fixpt.
+      cl_abap_unit_assert=>assert_subrc( msg = 'Invalid test source code' ).
+      mv_program_generated = abap_true.
+    ENDIF.
+  ENDMETHOD.
 
 ENDCLASS.
 
 CLASS ltcl_test IMPLEMENTATION.
 
+  DEFINE _code.
+    APPEND &1 TO mt_code.
+  END-OF-DEFINITION.
+
   METHOD setup.
+    CREATE OBJECT mo_program.
     CREATE OBJECT mo_check.
+    SET HANDLER message_handler FOR mo_check.
     zcl_aoc_unit_test=>set_check( mo_check ).
   ENDMETHOD.
+
+  METHOD teardown.
+    mo_program->cleanup( ).
+  ENDMETHOD.
+
+  METHOD message_handler.
+    mv_text = p_param_1.
+  ENDMETHOD.
+
 
   METHOD export_import.
     zcl_aoc_unit_test=>export_import( mo_check ).
   ENDMETHOD.
 
+  METHOD test_1.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'gv_p = 12345.'.
+
+    mo_program->generate_programm( mt_code ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'N'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = 12345'
+                                        act = mv_text ).
+  ENDMETHOD.
+
+  METHOD test_1_with_fixpt.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'gv_p = 12345.'.
+
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+  ENDMETHOD.
+
+  METHOD test_2.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'FORM assignment.'.
+    _code '  DATA gv_r TYPE p LENGTH 10 DECIMALS 3.'.
+    _code '  gv_p = gv_r.'.
+    _code 'ENDFORM.'.
+
+    mo_program->generate_programm( mt_code ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'E'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '001'
+                                        act = ms_result-code ).
+  ENDMETHOD.
+
+  METHOD test_3.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'FORM assignment.'.
+    _code '  DATA gv_r TYPE p LENGTH 10 DECIMALS 4.'.
+    _code '  gv_p = gv_r.'.
+    _code 'ENDFORM.'.
+
+    mo_program->generate_programm( mt_code ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'N'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = GV_R'
+                                        act = mv_text ).
+  ENDMETHOD.
+
+  METHOD test_4.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'gv_p = ''500.12''.'.
+
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'N'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = ''500.12'''
+                                        act = mv_text ).
+  ENDMETHOD.
+
+  METHOD test_5.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'gv_p = `500.12`.'.
+
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'N'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = `500.12`'
+                                        act = mv_text ).
+  ENDMETHOD.
+
+  METHOD test_6.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'gv_p = |500.12|.'.
+
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'N'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = |500.12|'
+                                        act = mv_text ).
+  ENDMETHOD.
+
+  METHOD test_7.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'DATA gv_i TYPE i.'.
+    _code 'gv_p = gv_i.'.
+
+    mo_program->generate_programm( mt_code ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_equals( exp = 'N'
+                                        act = ms_result-kind ).
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = GV_I'
+                                        act = mv_text ).
+  ENDMETHOD.
+
+  METHOD test_8.
+    _code 'REPORT.'.
+    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
+    _code 'DATA gv_i TYPE i.'.
+    _code 'gv_i = gv_p.'.
+
+    mo_program->generate_programm( mt_code ).
+
+    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+  ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_85.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_85.clas.testclasses.abap
@@ -1,5 +1,3 @@
-CLASS lcl_temporary_program DEFINITION DEFERRED.
-
 CLASS ltcl_test DEFINITION FOR TESTING
   DURATION SHORT
   RISK LEVEL HARMLESS
@@ -7,260 +5,23 @@ CLASS ltcl_test DEFINITION FOR TESTING
 
   PRIVATE SECTION.
     DATA:
-      mt_code    TYPE string_table,
-      ms_result  TYPE scirest_ad,
-      mv_text    TYPE string,
-      mo_program TYPE REF TO lcl_temporary_program,
-      mo_check   TYPE REF TO zcl_aoc_check_85.
+      mo_check  TYPE REF TO zcl_aoc_check_85.
 
     METHODS:
       setup,
-      teardown,
-      message_handler FOR EVENT message OF zcl_aoc_check_85 IMPORTING p_param_1,
-      export_import FOR TESTING,
-      test_1 FOR TESTING,
-      test_1_with_fixpt FOR TESTING,
-      test_2 FOR TESTING,
-      test_3 FOR TESTING,
-      test_4 FOR TESTING,
-      test_5 FOR TESTING,
-      test_6 FOR TESTING,
-      test_7 FOR TESTING,
-      test_8 FOR TESTING.
-
-ENDCLASS.
-
-CLASS lcl_temporary_program DEFINITION FOR TESTING FINAL.
-  PUBLIC SECTION.
-    TYPES:
-      t_program_name TYPE c LENGTH 30.
-    METHODS:
-      constructor,
-      cleanup,
-      get_program_name RETURNING VALUE(rv_program_name) TYPE t_program_name,
-      generate_programm IMPORTING it_source_code TYPE STANDARD TABLE iv_fixpt TYPE fixpt DEFAULT abap_false.
-
-  PRIVATE SECTION.
-    DATA:
-      mv_program_generated TYPE abap_bool,
-      mv_program_name      TYPE t_program_name.
-ENDCLASS.
-
-CLASS lcl_temporary_program IMPLEMENTATION.
-  METHOD constructor.
-    DATA:
-      lt_data TYPE STANDARD TABLE OF rbase.
-    mv_program_name = 'YAOC_CHECK_85_TEST'.
-
-    "find a free program name
-    LOAD REPORT mv_program_name PART 'BASE' INTO lt_data.
-    WHILE sy-subrc <> 4.
-      IF sy-index > 10.
-        CLEAR mv_program_name.
-        cl_abap_unit_assert=>abort( 'Can not find a free program name to generate report for testing'  ).
-        RETURN.
-      ENDIF.
-      mv_program_name = 'YAOC_CHECK_85_TEST' && '_' && sy-index.
-      LOAD REPORT mv_program_name PART 'BASE' INTO lt_data.
-    ENDWHILE.
-
-  ENDMETHOD.
-
-  METHOD get_program_name.
-    rv_program_name = mv_program_name.
-  ENDMETHOD.
-
-  METHOD cleanup.
-    IF mv_program_name IS NOT INITIAL AND mv_program_generated = abap_true.
-      DELETE REPORT mv_program_name.
-      mv_program_generated = abap_false.
-    ENDIF.
-  ENDMETHOD.
-
-  METHOD generate_programm.
-    IF mv_program_name IS NOT INITIAL.
-      INSERT REPORT mv_program_name
-        FROM it_source_code
-        FIXED-POINT ARITHMETIC iv_fixpt.
-      cl_abap_unit_assert=>assert_subrc( msg = 'Invalid test source code' ).
-      mv_program_generated = abap_true.
-    ENDIF.
-  ENDMETHOD.
+      export_import FOR TESTING.
 
 ENDCLASS.
 
 CLASS ltcl_test IMPLEMENTATION.
 
-  DEFINE _code.
-    APPEND &1 TO mt_code.
-  END-OF-DEFINITION.
-
   METHOD setup.
-    CREATE OBJECT mo_program.
     CREATE OBJECT mo_check.
-    SET HANDLER message_handler FOR mo_check.
     zcl_aoc_unit_test=>set_check( mo_check ).
   ENDMETHOD.
-
-  METHOD teardown.
-    mo_program->cleanup( ).
-  ENDMETHOD.
-
-  METHOD message_handler.
-    mv_text = p_param_1.
-  ENDMETHOD.
-
 
   METHOD export_import.
     zcl_aoc_unit_test=>export_import( mo_check ).
   ENDMETHOD.
 
-  METHOD test_1.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'gv_p = 12345.'.
-
-    mo_program->generate_programm( mt_code ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'N'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '002'
-                                        act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = 12345'
-                                        act = mv_text ).
-  ENDMETHOD.
-
-  METHOD test_1_with_fixpt.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'gv_p = 12345.'.
-
-    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_initial( ms_result ).
-  ENDMETHOD.
-
-  METHOD test_2.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'FORM assignment.'.
-    _code '  DATA gv_r TYPE p LENGTH 10 DECIMALS 3.'.
-    _code '  gv_p = gv_r.'.
-    _code 'ENDFORM.'.
-
-    mo_program->generate_programm( mt_code ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'E'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '001'
-                                        act = ms_result-code ).
-  ENDMETHOD.
-
-  METHOD test_3.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'FORM assignment.'.
-    _code '  DATA gv_r TYPE p LENGTH 10 DECIMALS 4.'.
-    _code '  gv_p = gv_r.'.
-    _code 'ENDFORM.'.
-
-    mo_program->generate_programm( mt_code ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'N'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '002'
-                                        act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = GV_R'
-                                        act = mv_text ).
-  ENDMETHOD.
-
-  METHOD test_4.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'gv_p = ''500.12''.'.
-
-    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'N'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '002'
-                                        act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = ''500.12'''
-                                        act = mv_text ).
-  ENDMETHOD.
-
-  METHOD test_5.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'gv_p = `500.12`.'.
-
-    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'N'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '002'
-                                        act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = `500.12`'
-                                        act = mv_text ).
-  ENDMETHOD.
-
-  METHOD test_6.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'gv_p = |500.12|.'.
-
-    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'N'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '002'
-                                        act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = |500.12|'
-                                        act = mv_text ).
-  ENDMETHOD.
-
-  METHOD test_7.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'DATA gv_i TYPE i.'.
-    _code 'gv_p = gv_i.'.
-
-    mo_program->generate_programm( mt_code ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_equals( exp = 'N'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '002'
-                                        act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = GV_I'
-                                        act = mv_text ).
-  ENDMETHOD.
-
-  METHOD test_8.
-    _code 'REPORT.'.
-    _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
-    _code 'DATA gv_i TYPE i.'.
-    _code 'gv_i = gv_p.'.
-
-    mo_program->generate_programm( mt_code ).
-
-    ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
-
-    cl_abap_unit_assert=>assert_initial( ms_result ).
-  ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_85.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_85.clas.testclasses.abap
@@ -1,4 +1,4 @@
-CLASS ltcl_temporary_program DEFINITION DEFERRED.
+CLASS lcl_temporary_program DEFINITION DEFERRED.
 
 CLASS ltcl_test DEFINITION FOR TESTING
   DURATION SHORT
@@ -7,31 +7,17 @@ CLASS ltcl_test DEFINITION FOR TESTING
 
   PRIVATE SECTION.
     DATA:
-      mo_check   TYPE REF TO zcl_aoc_check_85.
-
-    METHODS:
-      setup,
-      export_import FOR TESTING.
-
-ENDCLASS.
-
-CLASS ltcl_test_code DEFINITION FOR TESTING
-  DURATION SHORT
-  RISK LEVEL DANGEROUS
-  FINAL.
-
-  PRIVATE SECTION.
-    DATA:
       mt_code    TYPE string_table,
       ms_result  TYPE scirest_ad,
       mv_text    TYPE string,
-      mo_program TYPE REF TO ltcl_temporary_program,
+      mo_program TYPE REF TO lcl_temporary_program,
       mo_check   TYPE REF TO zcl_aoc_check_85.
 
     METHODS:
       setup,
       teardown,
       message_handler FOR EVENT message OF zcl_aoc_check_85 IMPORTING p_param_1,
+      export_import FOR TESTING,
       test_1 FOR TESTING,
       test_1_with_fixpt FOR TESTING,
       test_2 FOR TESTING,
@@ -44,7 +30,7 @@ CLASS ltcl_test_code DEFINITION FOR TESTING
 
 ENDCLASS.
 
-CLASS ltcl_temporary_program DEFINITION FOR TESTING FINAL.
+CLASS lcl_temporary_program DEFINITION FOR TESTING FINAL.
   PUBLIC SECTION.
     TYPES:
       t_program_name TYPE c LENGTH 30.
@@ -60,7 +46,7 @@ CLASS ltcl_temporary_program DEFINITION FOR TESTING FINAL.
       mv_program_name      TYPE t_program_name.
 ENDCLASS.
 
-CLASS ltcl_temporary_program IMPLEMENTATION.
+CLASS lcl_temporary_program IMPLEMENTATION.
   METHOD constructor.
     DATA:
       lt_data TYPE STANDARD TABLE OF rbase.
@@ -105,19 +91,6 @@ ENDCLASS.
 
 CLASS ltcl_test IMPLEMENTATION.
 
-  METHOD setup.
-    CREATE OBJECT mo_check.
-    zcl_aoc_unit_test=>set_check( mo_check ).
-  ENDMETHOD.
-
-  METHOD export_import.
-    zcl_aoc_unit_test=>export_import( mo_check ).
-  ENDMETHOD.
-
-ENDCLASS.
-
-CLASS ltcl_test_code IMPLEMENTATION.
-
   DEFINE _code.
     APPEND &1 TO mt_code.
   END-OF-DEFINITION.
@@ -130,12 +103,16 @@ CLASS ltcl_test_code IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD teardown.
-    CLEAR mv_text.
     mo_program->cleanup( ).
   ENDMETHOD.
 
   METHOD message_handler.
     mv_text = p_param_1.
+  ENDMETHOD.
+
+
+  METHOD export_import.
+    zcl_aoc_unit_test=>export_import( mo_check ).
   ENDMETHOD.
 
   METHOD test_1.
@@ -210,7 +187,7 @@ CLASS ltcl_test_code IMPLEMENTATION.
     _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
     _code 'gv_p = ''500.12''.'.
 
-    mo_program->generate_programm( it_source_code = mt_code ).
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
 
     ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
 
@@ -227,7 +204,7 @@ CLASS ltcl_test_code IMPLEMENTATION.
     _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
     _code 'gv_p = `500.12`.'.
 
-    mo_program->generate_programm( it_source_code = mt_code ).
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
 
     ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
 
@@ -244,7 +221,7 @@ CLASS ltcl_test_code IMPLEMENTATION.
     _code 'DATA gv_p TYPE p LENGTH 10 DECIMALS 3.'.
     _code 'gv_p = |500.12|.'.
 
-    mo_program->generate_programm( it_source_code = mt_code ).
+    mo_program->generate_programm( it_source_code = mt_code iv_fixpt = abap_true ).
 
     ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
 
@@ -252,7 +229,7 @@ CLASS ltcl_test_code IMPLEMENTATION.
                                         act = ms_result-kind ).
     cl_abap_unit_assert=>assert_equals( exp = '002'
                                         act = ms_result-code ).
-    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = | `500.12` |'
+    cl_abap_unit_assert=>assert_equals( exp = 'GV_P = |500.12|'
                                         act = mv_text ).
   ENDMETHOD.
 
@@ -284,9 +261,6 @@ CLASS ltcl_test_code IMPLEMENTATION.
 
     ms_result = zcl_aoc_unit_test=>check_program( mo_program->get_program_name( ) ).
 
-    cl_abap_unit_assert=>assert_equals( exp = 'E'
-                                        act = ms_result-kind ).
-    cl_abap_unit_assert=>assert_equals( exp = '001'
-                                        act = ms_result-code ).
+    cl_abap_unit_assert=>assert_initial( ms_result ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_85.clas.xml
+++ b/src/checks/zcl_aoc_check_85.clas.xml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_AOC_CHECK_85</CLSNAME>
+    <VERSION>1</VERSION>
+    <LANGU>E</LANGU>
+    <DESCRIPT>Activate fixed point arithmetic</DESCRIPT>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+    <RSTAT>P</RSTAT>
+    <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
+   </VSEOCLASS>
+   <LINES>
+    <TLINE>
+     <TDFORMAT>*</TDFORMAT>
+     <TDLINE>abapOpenChecks</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>*</TDFORMAT>
+     <TDLINE>https://github.com/larshp/abapOpenChecks</TDLINE>
+    </TLINE>
+    <TLINE>
+     <TDFORMAT>*</TDFORMAT>
+     <TDLINE>MIT License</TDLINE>
+    </TLINE>
+   </LINES>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/checks/zcl_aoc_unit_test.clas.abap
+++ b/src/checks/zcl_aoc_unit_test.clas.abap
@@ -28,11 +28,6 @@ CLASS zcl_aoc_unit_test DEFINITION
         !it_code         TYPE string_table
       RETURNING
         VALUE(rs_result) TYPE scirest_ad.
-    CLASS-METHODS check_program
-      IMPORTING
-        !iv_prgoram_name TYPE program
-      RETURNING
-        VALUE(rs_result) TYPE scirest_ad.
     CLASS-METHODS set_check
       IMPORTING
         !io_check TYPE REF TO zcl_aoc_super.
@@ -89,31 +84,6 @@ CLASS ZCL_AOC_UNIT_TEST IMPLEMENTATION.
       it_statements = lt_statements
       it_levels     = lt_levels
       it_structures = lt_structures ).
-
-    IF NOT gs_result-code IS INITIAL.
-      go_check->get_message_text(
-          p_test = ''
-          p_code = gs_result-code ).
-    ENDIF.
-
-    rs_result = gs_result.
-
-  ENDMETHOD.
-
-
-  METHOD check_program.
-
-* abapOpenChecks
-* https://github.com/larshp/abapOpenChecks
-* MIT License
-
-    CLEAR gs_result.
-    cl_abap_compiler=>clear_cache( ).
-    go_check->clear( ).
-
-    SET HANDLER handler FOR go_check.
-    go_check->program_name = iv_prgoram_name.
-    go_check->run( ).
 
     IF NOT gs_result-code IS INITIAL.
       go_check->get_message_text(

--- a/src/checks/zcl_aoc_unit_test.clas.abap
+++ b/src/checks/zcl_aoc_unit_test.clas.abap
@@ -28,6 +28,11 @@ CLASS zcl_aoc_unit_test DEFINITION
         !it_code         TYPE string_table
       RETURNING
         VALUE(rs_result) TYPE scirest_ad.
+    CLASS-METHODS check_program
+      IMPORTING
+        !iv_prgoram_name TYPE program
+      RETURNING
+        VALUE(rs_result) TYPE scirest_ad.
     CLASS-METHODS set_check
       IMPORTING
         !io_check TYPE REF TO zcl_aoc_super.
@@ -84,6 +89,31 @@ CLASS ZCL_AOC_UNIT_TEST IMPLEMENTATION.
       it_statements = lt_statements
       it_levels     = lt_levels
       it_structures = lt_structures ).
+
+    IF NOT gs_result-code IS INITIAL.
+      go_check->get_message_text(
+          p_test = ''
+          p_code = gs_result-code ).
+    ENDIF.
+
+    rs_result = gs_result.
+
+  ENDMETHOD.
+
+
+  METHOD check_program.
+
+* abapOpenChecks
+* https://github.com/larshp/abapOpenChecks
+* MIT License
+
+    CLEAR gs_result.
+    cl_abap_compiler=>clear_cache( ).
+    go_check->clear( ).
+
+    SET HANDLER handler FOR go_check.
+    go_check->program_name = iv_prgoram_name.
+    go_check->run( ).
 
     IF NOT gs_result-code IS INITIAL.
       go_check->get_message_text(


### PR DESCRIPTION
It's still work in process, because:
- I don't know how to write proper unit tests for this check because of the use of `cl_abap_compiler`
- string templates can't be detected because `get_full_name_for_position` of `cl_abap_compiler` returns an exception

This check runs, if fixed point arithmetic is not active.
If you can activate it safely, it will return the configured error type.
If you can't activate it safely, it will return info messages.

I used this program to test this check (includes results of check):
https://gist.github.com/pcf0/d184e57c1f4d0aa64f9217446bd880c5

closes #665 