### PR TITLE
Check 45 - Use NEW abc( ) expression - non-class-based exceptions

### DIFF
--- a/src/checks/zcl_aoc_check_45.clas.abap
+++ b/src/checks/zcl_aoc_check_45.clas.abap
@@ -75,6 +75,8 @@ CLASS ZCL_AOC_CHECK_45 IMPLEMENTATION.
         lv_code = '001'.
       ELSEIF <ls_statement>-str CP 'CREATE OBJECT *'
           AND NOT <ls_statement>-str CP '* TYPE (*'
+          AND NOT <ls_statement>-str CP '* EXCEPTIONS *'
+          AND NOT <ls_statement>-str CP '* AREA HANDLE *'
           AND mv_new = abap_true
           AND support_740sp02( ) = abap_true.
         lv_code = '002'.

--- a/src/checks/zcl_aoc_check_45.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_45.clas.testclasses.abap
@@ -27,6 +27,9 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test002_01 FOR TESTING,
       test002_02 FOR TESTING,
       test002_03 FOR TESTING,
+      test002_04 FOR TESTING,
+      test002_05 FOR TESTING,
+      test002_06 FOR TESTING,
       test004_01 FOR TESTING,
       test004_02 FOR TESTING,
       test005_01 FOR TESTING,
@@ -130,6 +133,48 @@ CLASS ltcl_test IMPLEMENTATION.
     ENDIF.
 
     _code 'CREATE OBJECT rr_result TYPE (ls_foo-command_class).'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test002_04.
+
+    IF mo_check->support_740sp02( ) = abap_false.
+      RETURN.
+    ENDIF.
+
+    _code 'CREATE OBJECT lo_new EXCEPTIONS foo = 4.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test002_05.
+
+    IF mo_check->support_740sp02( ) = abap_false.
+      RETURN.
+    ENDIF.
+
+    _code 'CREATE OBJECT lo_new EXCEPTIONS OTHERS = 4.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.
+
+  METHOD test002_06.
+
+    IF mo_check->support_740sp02( ) = abap_false.
+      RETURN.
+    ENDIF.
+
+    _code 'CREATE OBJECT lo_new AREA HANDLE lo_handle.'.
 
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 


### PR DESCRIPTION
@larshp the fix you suggested works.
I also found another statement which can't be fixed: [`CREATE OBJECT oref AREA HANDLE handle`](https://help.sap.com/doc/abapdocu_750_index_htm/7.50/en-US/abapcreate_object_area_handle.htm)

fix #261