### PR TITLE
Fix for CALL METHOD OF

### DIFF
--- a/src/checks/zcl_aoc_check_07.clas.abap
+++ b/src/checks/zcl_aoc_check_07.clas.abap
@@ -61,8 +61,9 @@ CLASS ZCL_AOC_CHECK_07 IMPLEMENTATION.
       IF <ls_token3>-str CP '*>(*'
           OR <ls_token3>-str CP '*)=>*'
           OR <ls_token3>-str CP '*)->*'
-          OR <ls_token3>-str CP '(*'.
-* allow dynamic calls
+          OR <ls_token3>-str CP '(*'
+          OR <ls_token3>-str = 'OF'.
+* allow dynamic calls and OLE interaction
         CONTINUE.
       ENDIF.
 


### PR DESCRIPTION
CALL METHOD OF is used for OLE (MS Office integration). It is still valid and therefore should not be detected as finding.