### PR TITLE
Fill table scimessages in constructor

### DIFF
--- a/src/checks/zcl_aoc_check_02.clas.abap
+++ b/src/checks/zcl_aoc_check_02.clas.abap
@@ -99,11 +99,9 @@ CLASS zcl_aoc_check_02 IMPLEMENTATION.
     mv_exit  = abap_true.
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'EXIT outside loop, use RETURN instead'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '002'
         iv_text = 'CHECK outside of loop'(m02) ).
 

--- a/src/checks/zcl_aoc_check_02.clas.abap
+++ b/src/checks/zcl_aoc_check_02.clas.abap
@@ -9,8 +9,6 @@ CLASS zcl_aoc_check_02 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
     METHODS if_ci_test~query_attributes
         REDEFINITION.
     METHODS put_attributes
@@ -26,7 +24,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_02 IMPLEMENTATION.
+CLASS zcl_aoc_check_02 IMPLEMENTATION.
 
 
   METHOD check.
@@ -100,6 +98,15 @@ CLASS ZCL_AOC_CHECK_02 IMPLEMENTATION.
     mv_check = abap_true.
     mv_exit  = abap_true.
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'EXIT outside loop, use RETURN instead'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '002'
+        iv_text = 'CHECK outside of loop'(m02) ).
+
   ENDMETHOD.
 
 
@@ -112,24 +119,6 @@ CLASS ZCL_AOC_CHECK_02 IMPLEMENTATION.
       TO DATA BUFFER p_attributes.
 
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'EXIT outside loop, use RETURN instead'.   "#EC NOTEXT
-      WHEN '002'.
-        p_text = 'CHECK outside of loop'.                   "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 
 
   METHOD if_ci_test~query_attributes.

--- a/src/checks/zcl_aoc_check_02.clas.xml
+++ b/src/checks/zcl_aoc_check_02.clas.xml
@@ -13,6 +13,20 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>EXIT outside loop, use RETURN instead</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M02</KEY>
+     <ENTRY>CHECK outside of loop</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_03.clas.abap
+++ b/src/checks/zcl_aoc_check_03.clas.abap
@@ -176,11 +176,9 @@ CLASS zcl_aoc_check_03 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'TRY without CATCH'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '002'
         iv_text = 'Nesting with same exception'(m02) ).
 

--- a/src/checks/zcl_aoc_check_03.clas.abap
+++ b/src/checks/zcl_aoc_check_03.clas.abap
@@ -9,8 +9,6 @@ CLASS zcl_aoc_check_03 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
   PROTECTED SECTION.
 
     METHODS check_nested
@@ -24,7 +22,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_03 IMPLEMENTATION.
+CLASS zcl_aoc_check_03 IMPLEMENTATION.
 
 
   METHOD check.
@@ -177,23 +175,14 @@ CLASS ZCL_AOC_CHECK_03 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'TRY without CATCH'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '002'
+        iv_text = 'Nesting with same exception'(m02) ).
+
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'TRY without CATCH'.                       "#EC NOTEXT
-      WHEN '002'.
-        p_text = 'Nesting with same exception'.             "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_03.clas.xml
+++ b/src/checks/zcl_aoc_check_03.clas.xml
@@ -13,6 +13,20 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>TRY without CATCH</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M02</KEY>
+     <ENTRY>Nesting with same exception</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_07.clas.abap
+++ b/src/checks/zcl_aoc_check_07.clas.abap
@@ -8,15 +8,13 @@ CLASS zcl_aoc_check_07 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_07 IMPLEMENTATION.
+CLASS zcl_aoc_check_07 IMPLEMENTATION.
 
 
   METHOD check.
@@ -126,23 +124,14 @@ CLASS ZCL_AOC_CHECK_07 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Use functional writing style'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '002'
+        iv_text = 'Use functional writing style instead of RECEIVING'(m02) ).
+
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Use functional writing style'.            "#EC NOTEXT
-      WHEN '002'.
-        p_text = 'Use functional writing style instead of RECEIVING'. "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_07.clas.abap
+++ b/src/checks/zcl_aoc_check_07.clas.abap
@@ -125,11 +125,9 @@ CLASS zcl_aoc_check_07 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Use functional writing style'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '002'
         iv_text = 'Use functional writing style instead of RECEIVING'(m02) ).
 

--- a/src/checks/zcl_aoc_check_07.clas.xml
+++ b/src/checks/zcl_aoc_check_07.clas.xml
@@ -13,6 +13,20 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Use functional writing style</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M02</KEY>
+     <ENTRY>Use functional writing style instead of RECEIVING</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_08.clas.abap
+++ b/src/checks/zcl_aoc_check_08.clas.abap
@@ -11,8 +11,6 @@ CLASS zcl_aoc_check_08 DEFINITION
         REDEFINITION.
     METHODS get_attributes
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
     METHODS put_attributes
         REDEFINITION.
     METHODS if_ci_test~query_attributes
@@ -55,7 +53,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_08 IMPLEMENTATION.
+CLASS zcl_aoc_check_08 IMPLEMENTATION.
 
 
   METHOD check.
@@ -184,6 +182,103 @@ CLASS ZCL_AOC_CHECK_08 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'REFRESH is obsolete'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '002'
+        iv_text = 'IS REQUESTED is obsolete'(m02) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '003'
+        iv_text = 'LEAVE is obsolete'(m03) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '004'
+        iv_text = 'COMPUTE is obsolete'(m04) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '005'
+        iv_text = 'MOVE is obsolete'(m05) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '006'
+        iv_text = 'Obsolete operator'(m06) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '007'
+        iv_text = 'Use new operator'(m07) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '008'
+        iv_text = 'DEMAND is obsolete'(m08) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '009'
+        iv_text = 'SUPPLY is obsolete'(m09) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '010'
+        iv_text = 'CONTEXTS is obsolete'(m10) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '011'
+        iv_text = 'ADD is obsolete'(m11) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '012'
+        iv_text = 'SUBTRACT is obsolete'(m12) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '013'
+        iv_text = 'MULTIPLY is obsolete'(m13) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '014'
+        iv_text = 'DIVIDE is obsolete'(m14) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '015'
+        iv_text = 'CALL DIALOG is obsolete'(m15) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '016'
+        iv_text = 'OCCURS is obsolete'(m16) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '017'
+        iv_text = 'WITH HEADER LINE is obsolete'(m17) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '018'
+        iv_text = 'RANGES declarations is obsolete'(m18) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '019'
+        iv_text = 'Arithmetic CORRESPONDING is obsolete'(m19) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '020'
+        iv_text = 'Do not use SET EXTENDED CHECK'(m20) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '021'
+        iv_text = 'LOCAL is obsolete'(m21) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '022'
+        iv_text = 'DO 1 TIMES'(m22) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '023'
+        iv_text = 'DO ... VARYING ...'(m23) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '024'
+        iv_text = 'CATCH SYSTEM-EXCEPTIONS is obsolete'(m24) ).
+
     mv_001 = abap_true.
     mv_002 = abap_true.
     mv_003 = abap_true.
@@ -243,68 +338,6 @@ CLASS ZCL_AOC_CHECK_08 IMPLEMENTATION.
       TO DATA BUFFER p_attributes.
 
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'REFRESH is obsolete'.                     "#EC NOTEXT
-      WHEN '002'.
-        p_text = 'IS REQUESTED is obsolete'.                "#EC NOTEXT
-      WHEN '003'.
-        p_text = 'LEAVE is obsolete'.                       "#EC NOTEXT
-      WHEN '004'.
-        p_text = 'COMPUTE is obsolete'.                     "#EC NOTEXT
-      WHEN '005'.
-        p_text = 'MOVE is obsolete'.                        "#EC NOTEXT
-      WHEN '006'.
-        p_text = 'Obsolete operator'.                       "#EC NOTEXT
-      WHEN '007'.
-        p_text = 'Use new operator'.                        "#EC NOTEXT
-      WHEN '008'.
-        p_text = 'DEMAND is obsolete'.                      "#EC NOTEXT
-      WHEN '009'.
-        p_text = 'SUPPLY is obsolete'.                      "#EC NOTEXT
-      WHEN '010'.
-        p_text = 'CONTEXTS is obsolete'.                    "#EC NOTEXT
-      WHEN '011'.
-        p_text = 'ADD is obsolete'.                         "#EC NOTEXT
-      WHEN '012'.
-        p_text = 'SUBTRACT is obsolete'.                    "#EC NOTEXT
-      WHEN '013'.
-        p_text = 'MULTIPLY is obsolete'.                    "#EC NOTEXT
-      WHEN '014'.
-        p_text = 'DIVIDE is obsolete'.                      "#EC NOTEXT
-      WHEN '015'.
-        p_text = 'CALL DIALOG is obsolete'.                 "#EC NOTEXT
-      WHEN '016'.
-        p_text = 'OCCURS is obsolete'.                      "#EC NOTEXT
-      WHEN '017'.
-        p_text = 'WITH HEADER LINE is obsolete'.            "#EC NOTEXT
-      WHEN '018'.
-        p_text = 'RANGES declarations is obsolete'.         "#EC NOTEXT
-      WHEN '019'.
-        p_text = 'Arithmetic CORRESPONDING is obsolete'.    "#EC NOTEXT
-      WHEN '020'.
-        p_text = 'Do not use SET EXTENDED CHECK'.           "#EC NOTEXT
-      WHEN '021'.
-        p_text = 'LOCAL is obsolete'.                       "#EC NOTEXT
-      WHEN '022'.
-        p_text = 'DO 1 TIMES'.                              "#EC NOTEXT
-      WHEN '023'.
-        p_text = 'DO ... VARYING ...'.                      "#EC NOTEXT
-      WHEN '024'.
-        p_text = 'CATCH SYSTEM-EXCEPTIONS is obsolete'.     "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 
 
   METHOD if_ci_test~query_attributes.

--- a/src/checks/zcl_aoc_check_08.clas.abap
+++ b/src/checks/zcl_aoc_check_08.clas.abap
@@ -183,99 +183,75 @@ CLASS zcl_aoc_check_08 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'REFRESH is obsolete'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '002'
         iv_text = 'IS REQUESTED is obsolete'(m02) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '003'
         iv_text = 'LEAVE is obsolete'(m03) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '004'
         iv_text = 'COMPUTE is obsolete'(m04) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '005'
         iv_text = 'MOVE is obsolete'(m05) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '006'
         iv_text = 'Obsolete operator'(m06) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '007'
         iv_text = 'Use new operator'(m07) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '008'
         iv_text = 'DEMAND is obsolete'(m08) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '009'
         iv_text = 'SUPPLY is obsolete'(m09) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '010'
         iv_text = 'CONTEXTS is obsolete'(m10) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '011'
         iv_text = 'ADD is obsolete'(m11) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '012'
         iv_text = 'SUBTRACT is obsolete'(m12) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '013'
         iv_text = 'MULTIPLY is obsolete'(m13) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '014'
         iv_text = 'DIVIDE is obsolete'(m14) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '015'
         iv_text = 'CALL DIALOG is obsolete'(m15) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '016'
         iv_text = 'OCCURS is obsolete'(m16) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '017'
         iv_text = 'WITH HEADER LINE is obsolete'(m17) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '018'
         iv_text = 'RANGES declarations is obsolete'(m18) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '019'
         iv_text = 'Arithmetic CORRESPONDING is obsolete'(m19) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '020'
         iv_text = 'Do not use SET EXTENDED CHECK'(m20) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '021'
         iv_text = 'LOCAL is obsolete'(m21) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '022'
         iv_text = 'DO 1 TIMES'(m22) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '023'
         iv_text = 'DO ... VARYING ...'(m23) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '024'
         iv_text = 'CATCH SYSTEM-EXCEPTIONS is obsolete'(m24) ).
 

--- a/src/checks/zcl_aoc_check_08.clas.xml
+++ b/src/checks/zcl_aoc_check_08.clas.xml
@@ -13,6 +13,152 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>REFRESH is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M02</KEY>
+     <ENTRY>IS REQUESTED is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M03</KEY>
+     <ENTRY>LEAVE is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M04</KEY>
+     <ENTRY>COMPUTE is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M05</KEY>
+     <ENTRY>MOVE is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M06</KEY>
+     <ENTRY>Obsolete operator</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M07</KEY>
+     <ENTRY>Use new operator</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M08</KEY>
+     <ENTRY>DEMAND is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M09</KEY>
+     <ENTRY>SUPPLY is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M10</KEY>
+     <ENTRY>CONTEXTS is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M11</KEY>
+     <ENTRY>ADD is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M12</KEY>
+     <ENTRY>SUBTRACT is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M13</KEY>
+     <ENTRY>MULTIPLY is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M14</KEY>
+     <ENTRY>DIVIDE is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M15</KEY>
+     <ENTRY>CALL DIALOG is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M16</KEY>
+     <ENTRY>OCCURS is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M17</KEY>
+     <ENTRY>WITH HEADER LINE is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M18</KEY>
+     <ENTRY>RANGES declarations is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M19</KEY>
+     <ENTRY>Arithmetic CORRESPONDING is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M20</KEY>
+     <ENTRY>Do not use SET EXTENDED CHECK</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M21</KEY>
+     <ENTRY>LOCAL is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M22</KEY>
+     <ENTRY>DO 1 TIMES</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M23</KEY>
+     <ENTRY>DO ... VARYING ...</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M24</KEY>
+     <ENTRY>CATCH SYSTEM-EXCEPTIONS is obsolete</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_10.clas.abap
+++ b/src/checks/zcl_aoc_check_10.clas.abap
@@ -8,15 +8,13 @@ CLASS zcl_aoc_check_10 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_10 IMPLEMENTATION.
+CLASS zcl_aoc_check_10 IMPLEMENTATION.
 
 
   METHOD check.
@@ -66,21 +64,10 @@ CLASS ZCL_AOC_CHECK_10 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Use icon_ constants'(m01) ).
+
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Use icon_ constants'.                     "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_10.clas.abap
+++ b/src/checks/zcl_aoc_check_10.clas.abap
@@ -65,7 +65,6 @@ CLASS zcl_aoc_check_10 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Use icon_ constants'(m01) ).
 

--- a/src/checks/zcl_aoc_check_10.clas.xml
+++ b/src/checks/zcl_aoc_check_10.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Use icon_ constants</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_11.clas.abap
+++ b/src/checks/zcl_aoc_check_11.clas.abap
@@ -108,7 +108,6 @@ CLASS zcl_aoc_check_11 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Max one statement per line'(m01) ).
 

--- a/src/checks/zcl_aoc_check_11.clas.abap
+++ b/src/checks/zcl_aoc_check_11.clas.abap
@@ -11,8 +11,6 @@ CLASS zcl_aoc_check_11 DEFINITION
         REDEFINITION.
     METHODS get_attributes
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
     METHODS if_ci_test~query_attributes
         REDEFINITION.
     METHODS put_attributes
@@ -25,7 +23,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_11 IMPLEMENTATION.
+CLASS zcl_aoc_check_11 IMPLEMENTATION.
 
 
   METHOD check.
@@ -109,6 +107,11 @@ CLASS ZCL_AOC_CHECK_11 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Max one statement per line'(m01) ).
+
     mv_skipc = abap_true.
 
   ENDMETHOD.
@@ -122,22 +125,6 @@ CLASS ZCL_AOC_CHECK_11 IMPLEMENTATION.
       TO DATA BUFFER p_attributes.
 
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Max one statement per line'.              "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 
 
   METHOD if_ci_test~query_attributes.

--- a/src/checks/zcl_aoc_check_11.clas.xml
+++ b/src/checks/zcl_aoc_check_11.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Max one statement per line</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_15.clas.abap
+++ b/src/checks/zcl_aoc_check_15.clas.abap
@@ -89,7 +89,6 @@ CLASS zcl_aoc_check_15 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Kernel CALL'(m01) ).
 

--- a/src/checks/zcl_aoc_check_15.clas.abap
+++ b/src/checks/zcl_aoc_check_15.clas.abap
@@ -9,15 +9,13 @@ CLASS zcl_aoc_check_15 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_15 IMPLEMENTATION.
+CLASS zcl_aoc_check_15 IMPLEMENTATION.
 
 
   METHOD check.
@@ -90,21 +88,10 @@ CLASS ZCL_AOC_CHECK_15 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Kernel CALL'(m01) ).
+
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Kernel CALL'.                             "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_15.clas.xml
+++ b/src/checks/zcl_aoc_check_15.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Kernel CALL</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_18.clas.abap
+++ b/src/checks/zcl_aoc_check_18.clas.abap
@@ -8,15 +8,13 @@ CLASS zcl_aoc_check_18 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_18 IMPLEMENTATION.
+CLASS zcl_aoc_check_18 IMPLEMENTATION.
 
 
   METHOD check.
@@ -89,21 +87,10 @@ CLASS ZCL_AOC_CHECK_18 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Empty branch'(m01) ).
+
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Empty branch'.                            "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_18.clas.abap
+++ b/src/checks/zcl_aoc_check_18.clas.abap
@@ -88,7 +88,6 @@ CLASS zcl_aoc_check_18 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Empty branch'(m01) ).
 

--- a/src/checks/zcl_aoc_check_18.clas.xml
+++ b/src/checks/zcl_aoc_check_18.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Empty branch</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_21.clas.abap
+++ b/src/checks/zcl_aoc_check_21.clas.abap
@@ -8,8 +8,6 @@ CLASS zcl_aoc_check_21 DEFINITION
 
     METHODS check
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
   PROTECTED SECTION.
 
     METHODS build_statement
@@ -28,7 +26,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_21 IMPLEMENTATION.
+CLASS zcl_aoc_check_21 IMPLEMENTATION.
 
 
   METHOD build_statement.
@@ -128,6 +126,11 @@ CLASS ZCL_AOC_CHECK_21 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Unused FORM parameter &1'(m01) ).
+
   ENDMETHOD.
 
 
@@ -151,20 +154,4 @@ CLASS ZCL_AOC_CHECK_21 IMPLEMENTATION.
     ENDLOOP.
 
   ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Unused FORM parameter &1'.                "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
-
-  ENDMETHOD.                    "GET_MESSAGE_TEXT
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_21.clas.abap
+++ b/src/checks/zcl_aoc_check_21.clas.abap
@@ -127,7 +127,6 @@ CLASS zcl_aoc_check_21 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Unused FORM parameter &1'(m01) ).
 

--- a/src/checks/zcl_aoc_check_21.clas.xml
+++ b/src/checks/zcl_aoc_check_21.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Unused FORM parameter &amp;1</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_53.clas.abap
+++ b/src/checks/zcl_aoc_check_53.clas.abap
@@ -8,8 +8,6 @@ CLASS zcl_aoc_check_53 DEFINITION PUBLIC INHERITING FROM zcl_aoc_super CREATE PU
         REDEFINITION.
     METHODS get_attributes
         REDEFINITION.
-    METHODS get_message_text
-        REDEFINITION.
     METHODS put_attributes
         REDEFINITION.
     METHODS if_ci_test~query_attributes
@@ -34,7 +32,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_53 IMPLEMENTATION.
+CLASS zcl_aoc_check_53 IMPLEMENTATION.
 
 
   METHOD check.
@@ -150,6 +148,59 @@ CLASS ZCL_AOC_CHECK_53 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '002'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '003'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '004'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '005'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '006'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '007'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '008'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '009'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '010'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '011'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '012'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+    insert_scimessage(
+      EXPORTING
+        iv_code = '013'
+        iv_text = 'Function &1 used, see documentation'(m01) ).
+
     mv_reuse_alv_grid_display    = abap_true.
     mv_so_new_document_att_send  = abap_true.
     mv_sapgui_progress_indicator = abap_true.
@@ -185,15 +236,6 @@ CLASS ZCL_AOC_CHECK_53 IMPLEMENTATION.
       mv_base64                    = mv_base64
       mv_binary                    = mv_binary
       TO DATA BUFFER p_attributes.
-
-  ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    p_text = 'Function &1 used, see documentation'.         "#EC NOTEXT
 
   ENDMETHOD.
 

--- a/src/checks/zcl_aoc_check_53.clas.abap
+++ b/src/checks/zcl_aoc_check_53.clas.abap
@@ -149,55 +149,42 @@ CLASS zcl_aoc_check_53 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '002'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '003'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '004'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '005'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '006'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '007'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '008'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '009'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '010'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '011'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '012'
         iv_text = 'Function &1 used, see documentation'(m01) ).
     insert_scimessage(
-      EXPORTING
         iv_code = '013'
         iv_text = 'Function &1 used, see documentation'(m01) ).
 

--- a/src/checks/zcl_aoc_check_53.clas.xml
+++ b/src/checks/zcl_aoc_check_53.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Function &amp;1 used, see documentation</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_54.clas.abap
+++ b/src/checks/zcl_aoc_check_54.clas.abap
@@ -5,16 +5,14 @@ CLASS zcl_aoc_check_54 DEFINITION PUBLIC INHERITING FROM zcl_aoc_super CREATE PU
     METHODS constructor .
 
     METHODS check
-      REDEFINITION .
-    METHODS get_message_text
-      REDEFINITION .
+        REDEFINITION .
   PROTECTED SECTION.
   PRIVATE SECTION.
 ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_54 IMPLEMENTATION.
+CLASS zcl_aoc_check_54 IMPLEMENTATION.
 
 
   METHOD check.
@@ -66,21 +64,10 @@ CLASS ZCL_AOC_CHECK_54 IMPLEMENTATION.
     enable_rfc( ).
     set_uses_checksum( ).
 
-  ENDMETHOD.
-
-
-  METHOD get_message_text.
-
-    CLEAR p_text.
-
-    CASE p_code.
-      WHEN '001'.
-        p_text = 'Specify AUTHORITY-CHECK'.                 "#EC NOTEXT
-      WHEN OTHERS.
-        super->get_message_text( EXPORTING p_test = p_test
-                                           p_code = p_code
-                                 IMPORTING p_text = p_text ).
-    ENDCASE.
+    insert_scimessage(
+      EXPORTING
+        iv_code = '001'
+        iv_text = 'Specify AUTHORITY-CHECK'(m01) ).
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_54.clas.abap
+++ b/src/checks/zcl_aoc_check_54.clas.abap
@@ -65,7 +65,6 @@ CLASS zcl_aoc_check_54 IMPLEMENTATION.
     set_uses_checksum( ).
 
     insert_scimessage(
-      EXPORTING
         iv_code = '001'
         iv_text = 'Specify AUTHORITY-CHECK'(m01) ).
 

--- a/src/checks/zcl_aoc_check_54.clas.xml
+++ b/src/checks/zcl_aoc_check_54.clas.xml
@@ -13,6 +13,14 @@
     <RSTAT>P</RSTAT>
     <WITH_UNIT_TESTS>X</WITH_UNIT_TESTS>
    </VSEOCLASS>
+   <TPOOL>
+    <item>
+     <ID>I</ID>
+     <KEY>M01</KEY>
+     <ENTRY>Specify AUTHORITY-CHECK</ENTRY>
+     <LENGTH>132</LENGTH>
+    </item>
+   </TPOOL>
    <LINES>
     <TLINE>
      <TDFORMAT>*</TDFORMAT>

--- a/src/checks/zcl_aoc_check_89.clas.abap
+++ b/src/checks/zcl_aoc_check_89.clas.abap
@@ -35,7 +35,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_89 IMPLEMENTATION.
+CLASS zcl_aoc_check_89 IMPLEMENTATION.
 
 
   METHOD check.
@@ -73,7 +73,6 @@ CLASS ZCL_AOC_CHECK_89 IMPLEMENTATION.
 
   METHOD constructor.
 
-    DATA ls_scimessage TYPE scimessage.
     super->constructor( ).
 
     version        = '001'.
@@ -84,16 +83,11 @@ CLASS ZCL_AOC_CHECK_89 IMPLEMENTATION.
 
     enable_rfc( ).
 
+    insert_scimessage(
+        iv_code = '001'
+        iv_text = 'Minimum lines of documentation not reached: &1'(m01) ).
+
     mv_minlength = 10.
-
-    ls_scimessage-test = myname.
-    ls_scimessage-code = '001'.
-    ls_scimessage-kind = c_error.
-    ls_scimessage-text = 'Minimum lines of documentation not reached: &1'(m01).
-    ls_scimessage-pcom = ''.
-    ls_scimessage-pcom_alt = ''.
-
-    INSERT ls_scimessage INTO TABLE scimessages.
 
   ENDMETHOD.
 

--- a/src/checks/zcl_aoc_check_91.clas.abap
+++ b/src/checks/zcl_aoc_check_91.clas.abap
@@ -25,7 +25,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_91 IMPLEMENTATION.
+CLASS zcl_aoc_check_91 IMPLEMENTATION.
 
 
   METHOD check.
@@ -86,8 +86,6 @@ CLASS ZCL_AOC_CHECK_91 IMPLEMENTATION.
 
   METHOD constructor.
 
-    DATA ls_scimessage TYPE scimessage.
-
     super->constructor( ).
 
     version        = '001'.
@@ -98,14 +96,11 @@ CLASS ZCL_AOC_CHECK_91 IMPLEMENTATION.
 
     enable_rfc( ).
 
+    insert_scimessage(
+        iv_code = '001'
+        iv_text = 'Maximum statements per processing block exceeded: &1'(m01) ).
+
     mv_maxlength = 50.
-
-    ls_scimessage-test = myname.
-    ls_scimessage-code = '001'.
-    ls_scimessage-kind = c_error.
-    ls_scimessage-text = 'Maximum statements per processing block exceeded: &1'(m01).
-
-    INSERT ls_scimessage INTO TABLE scimessages.
 
   ENDMETHOD.
 

--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -40,6 +40,7 @@ CLASS zcl_aoc_super DEFINITION
         srcid   TYPE sysuuid_x,
         rfcdest TYPE rfcdest,
       END OF ty_destination_cache .
+    TYPES ty_scimessage_text TYPE c LENGTH 255.
 
     DATA mv_errty TYPE sci_errty .
     CLASS-DATA gs_destination_cache TYPE ty_destination_cache .
@@ -64,7 +65,7 @@ CLASS zcl_aoc_super DEFINITION
     METHODS insert_scimessage
       IMPORTING
         iv_code TYPE scimessage-code
-        iv_text TYPE text255.
+        iv_text TYPE ty_scimessage_text.
 
     METHODS inform
         REDEFINITION .

--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -61,6 +61,14 @@ CLASS zcl_aoc_super DEFINITION
       RETURNING
         VALUE(rv_bool) TYPE abap_bool .
     METHODS set_uses_checksum .
+    METHODS insert_scimessage
+      IMPORTING
+        iv_test     TYPE scimessage-test OPTIONAL
+        iv_code     TYPE scimessage-code
+        iv_kind     TYPE scimessage-kind OPTIONAL
+        iv_text     TYPE text255
+        iv_pcom     TYPE scimessage-pcom OPTIONAL
+        iv_pcom_alt TYPE scimessage-pcom_alt OPTIONAL.
 
     METHODS get_include
         REDEFINITION .
@@ -94,7 +102,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_SUPER IMPLEMENTATION.
+CLASS zcl_aoc_super IMPLEMENTATION.
 
 
   METHOD check.
@@ -623,6 +631,33 @@ CLASS ZCL_AOC_SUPER IMPLEMENTATION.
     IF sy-subrc = 0.
       <lv_uses_checksum> = abap_true.
     ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD insert_scimessage.
+
+* Insert entry into table scimessages. This table is used to determine the message text for a finding.
+    DATA ls_scimessage LIKE LINE OF scimessages.
+
+    IF iv_test IS NOT INITIAL.
+      ls_scimessage-test = iv_test.
+    ELSE.
+      ls_scimessage-test = myname.
+    ENDIF.
+
+    IF iv_kind IS NOT INITIAL.
+      ls_scimessage-kind = iv_kind.
+    ELSE.
+      ls_scimessage-kind = mv_errty.
+    ENDIF.
+
+    ls_scimessage-code     = iv_code.
+    ls_scimessage-text     = iv_text.
+    ls_scimessage-pcom     = iv_pcom.
+    ls_scimessage-pcom_alt = iv_pcom_alt.
+
+    INSERT ls_scimessage INTO TABLE scimessages.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -66,8 +66,6 @@ CLASS zcl_aoc_super DEFINITION
         iv_code TYPE scimessage-code
         iv_text TYPE text255.
 
-    METHODS get_include
-        REDEFINITION .
     METHODS inform
         REDEFINITION .
   PRIVATE SECTION.
@@ -311,23 +309,6 @@ CLASS zcl_aoc_super IMPLEMENTATION.
             cx_sy_dyn_call_illegal_method.
         rv_result = |NONE|.
     ENDTRY.
-
-  ENDMETHOD.
-
-
-  METHOD get_include.
-
-    IF p_level = 0.
-* in case INCLUDE doesnt exist in the system
-      RETURN.
-    ENDIF.
-
-    IF ref_scan IS BOUND.
-* not bound during unit testing
-      p_result = super->get_include(
-          p_ref_scan = p_ref_scan
-          p_level    = p_level ).
-    ENDIF.
 
   ENDMETHOD.
 

--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -63,13 +63,11 @@ CLASS zcl_aoc_super DEFINITION
     METHODS set_uses_checksum .
     METHODS insert_scimessage
       IMPORTING
-        iv_test     TYPE scimessage-test OPTIONAL
-        iv_code     TYPE scimessage-code
-        iv_kind     TYPE scimessage-kind OPTIONAL
-        iv_text     TYPE text255
-        iv_pcom     TYPE scimessage-pcom OPTIONAL
-        iv_pcom_alt TYPE scimessage-pcom_alt OPTIONAL.
+        iv_code TYPE scimessage-code
+        iv_text TYPE text255.
 
+    METHODS get_include
+        REDEFINITION .
     METHODS inform
         REDEFINITION .
   PRIVATE SECTION.
@@ -313,6 +311,23 @@ CLASS zcl_aoc_super IMPLEMENTATION.
             cx_sy_dyn_call_illegal_method.
         rv_result = |NONE|.
     ENDTRY.
+
+  ENDMETHOD.
+
+
+  METHOD get_include.
+
+    IF p_level = 0.
+* in case INCLUDE doesnt exist in the system
+      RETURN.
+    ENDIF.
+
+    IF ref_scan IS BOUND.
+* not bound during unit testing
+      p_result = super->get_include(
+          p_ref_scan = p_ref_scan
+          p_level    = p_level ).
+    ENDIF.
 
   ENDMETHOD.
 
@@ -621,22 +636,10 @@ CLASS zcl_aoc_super IMPLEMENTATION.
 * Insert entry into table scimessages. This table is used to determine the message text for a finding.
     DATA ls_scimessage LIKE LINE OF scimessages.
 
-    IF iv_test IS NOT INITIAL.
-      ls_scimessage-test = iv_test.
-    ELSE.
-      ls_scimessage-test = myname.
-    ENDIF.
-
-    IF iv_kind IS NOT INITIAL.
-      ls_scimessage-kind = iv_kind.
-    ELSE.
-      ls_scimessage-kind = mv_errty.
-    ENDIF.
-
-    ls_scimessage-code     = iv_code.
-    ls_scimessage-text     = iv_text.
-    ls_scimessage-pcom     = iv_pcom.
-    ls_scimessage-pcom_alt = iv_pcom_alt.
+    ls_scimessage-test = myname.
+    ls_scimessage-code = iv_code.
+    ls_scimessage-kind = mv_errty.
+    ls_scimessage-text = iv_text.
 
     INSERT ls_scimessage INTO TABLE scimessages.
 


### PR DESCRIPTION
As discussed in https://github.com/larshp/abapOpenChecks/pull/692 and https://github.com/larshp/abapOpenChecks/issues/698, table scimessages should be filled in the constructor. This table is used to evaluate the texts for findings.

This commit includes the necessary changes in class zcl_aoc_super and adjusts a few checks.