### PR TITLE
Check 40 - Check SY-SUBRC - false positive check with if

### DIFF
--- a/src/checks/zcl_aoc_check_40.clas.abap
+++ b/src/checks/zcl_aoc_check_40.clas.abap
@@ -69,6 +69,21 @@ CLASS ZCL_AOC_CHECK_40 IMPLEMENTATION.
         ENDIF.
       ENDLOOP.
 
+      "re-check return code of last statement within IF/CASE-clause
+      LOOP AT lt_stack INTO ls_stack WHERE stackposition = lv_stack.
+        IF NOT lv_statement CP '* SY-SUBRC *'
+            AND NOT lv_statement CP '*CL_ABAP_UNIT_ASSERT=>ASSERT_SUBRC*'.
+          lv_include = io_scan->get_include( <ls_statement>-level ).
+          inform( p_sub_obj_name = lv_include
+                  p_line         = ls_stack-row
+                  p_kind         = mv_errty
+                  p_position     = ls_stack-position
+                  p_test         = myname
+                  p_code         = '001' ).
+        ENDIF.
+      ENDLOOP.
+      DELETE lt_stack WHERE stackposition = lv_stack.
+
       IF lv_statement CP 'IF *' OR lv_statement CP 'CASE *'.
         lv_stack = lv_stack + 1.
       ENDIF.
@@ -118,23 +133,19 @@ CLASS ZCL_AOC_CHECK_40 IMPLEMENTATION.
                 p_code         = '001' ).
       ENDIF.
 
-      "re-check return code of last statement within IF/CASE-clause
-      LOOP AT lt_stack INTO ls_stack WHERE stackposition = lv_stack.
-        IF NOT lv_statement CP '* SY-SUBRC *'
-            AND NOT lv_statement CP '*CL_ABAP_UNIT_ASSERT=>ASSERT_SUBRC*'.
-          lv_include = io_scan->get_include( <ls_statement>-level ).
-          inform( p_sub_obj_name = lv_include
-                  p_line         = ls_stack-row
-                  p_kind         = mv_errty
-                  p_position     = ls_stack-position
-                  p_test         = myname
-                  p_code         = '001' ).
-        ENDIF.
-      ENDLOOP.
-      DELETE lt_stack WHERE stackposition = lv_stack.
-
       lv_check = abap_false.
 
+    ENDLOOP.
+
+    "all remaining elements in the stack are positive
+    LOOP AT lt_stack INTO ls_stack.
+      lv_include = io_scan->get_include( <ls_statement>-level ).
+      inform( p_sub_obj_name = lv_include
+              p_line         = ls_stack-row
+              p_kind         = mv_errty
+              p_position     = ls_stack-position
+              p_test         = myname
+              p_code         = '001' ).
     ENDLOOP.
 
   ENDMETHOD.

--- a/src/checks/zcl_aoc_check_40.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_40.clas.testclasses.abap
@@ -33,7 +33,8 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test001_11 FOR TESTING,
       test001_12 FOR TESTING,
       test001_13 FOR TESTING,
-      test001_14 FOR TESTING.
+      test001_14 FOR TESTING,
+      test001_15 FOR TESTING.
 
 ENDCLASS.       "lcl_Test
 
@@ -303,6 +304,23 @@ CLASS ltcl_test IMPLEMENTATION.
                                         act = ms_result-code ).
     cl_abap_unit_assert=>assert_equals( exp = 2
                                         act = ms_result-line ).
+  ENDMETHOD.
+
+  METHOD test001_15.
+    _code 'IF sy-subrc = 8.'.
+    _code '  READ TABLE lt_table INDEX 1 INTO ls_table.'.
+    _code 'ELSEIF sy-subrc = 4.'.
+    _code '  READ TABLE lt_table INDEX 2 INTO ls_table.'.
+    _code 'ELSE.'.
+    _code '  READ TABLE lt_table INDEX 3 INTO ls_table.'.
+    _code 'ENDIF.'.
+    _code 'IF sy-subrc = 0.'.
+    _code '  WRITE: / ''success''.'.
+    _code 'ENDIF.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
   ENDMETHOD.
 
 ENDCLASS.       "lcl_Test


### PR DESCRIPTION
I indentified and fixed two problems:
1. if you have an `ASSERT sy-subrc = 0` it's allright. But if you have an `IF sy-subrc = 0.` then the `lv_stack` is increased first, which means that the condition in the `LOOP AT lt_stack` is not fulfilled.
2. the `inform` is not called if the last statement is a `READ TABLE`, `ENDIF` or `ENDCASE`

fix #767