### PR TITLE
Adjusted check 27 to handle inline declarations

### DIFF
--- a/src/checks/zcl_aoc_check_27.clas.abap
+++ b/src/checks/zcl_aoc_check_27.clas.abap
@@ -47,7 +47,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_27 IMPLEMENTATION.
+CLASS zcl_aoc_check_27 IMPLEMENTATION.
 
 
   METHOD analyze.
@@ -216,7 +216,12 @@ CLASS ZCL_AOC_CHECK_27 IMPLEMENTATION.
 
     READ TABLE it_statements INDEX lv_index INTO ls_statement.
     ASSERT sy-subrc = 0.
-    SPLIT ls_statement-statement AT space INTO lv_trash lv_var.
+    IF ls_statement-statement CP |DATA(*) *|.
+      SPLIT ls_statement-statement AT '(' INTO lv_trash lv_var.
+      SPLIT lv_var AT ')' INTO lv_var lv_trash.
+    ELSE.
+      SPLIT ls_statement-statement AT space INTO lv_trash lv_var.
+    ENDIF.
 
     WHILE lv_index > 0.
 
@@ -229,7 +234,8 @@ CLASS ZCL_AOC_CHECK_27 IMPLEMENTATION.
       ENDIF.
 
       IF ls_statement-statement CP |DATA { lv_var } *|
-          OR ls_statement-statement = |DATA { lv_var }|.
+          OR ls_statement-statement = |DATA { lv_var }|
+          OR ls_statement-statement CP |DATA({ lv_var }) *|.
         rv_bool = abap_true.
         RETURN.
       ENDIF.

--- a/src/checks/zcl_aoc_check_27.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_27.clas.testclasses.abap
@@ -28,6 +28,7 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test002_01 FOR TESTING,
       test002_02 FOR TESTING,
       test002_03 FOR TESTING,
+      test002_04 FOR TESTING,
       test003_01 FOR TESTING.
 
 ENDCLASS.       "lcl_Test
@@ -198,6 +199,21 @@ CLASS ltcl_test IMPLEMENTATION.
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 
     cl_abap_unit_assert=>assert_initial( ms_result ).
+
+  ENDMETHOD.
+
+  METHOD test002_04.
+* ===========
+
+    _code 'FORM foo.'.
+    _code '  DATA(bar) = `ABCD`.'.
+    _code '  CLEAR bar.'.
+    _code 'ENDFORM.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_equals( exp = '002'
+                                        act = ms_result-code ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Check 27 was not able to handle inline declarations. I added a unit test for this and also provided a solution.