### PR TITLE
Customer namespace /0CUST/ for Z objects

### DIFF
--- a/src/utils/zcl_aoc_util_reg_atc_namespace.clas.abap
+++ b/src/utils/zcl_aoc_util_reg_atc_namespace.clas.abap
@@ -84,7 +84,7 @@ CLASS zcl_aoc_util_reg_atc_namespace IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    IF lv_namespace IS INITIAL.
+    IF lv_namespace IS INITIAL OR lv_namespace = '/0CUST/'.
       RETURN.
     ENDIF.
 
@@ -112,7 +112,7 @@ CLASS zcl_aoc_util_reg_atc_namespace IMPLEMENTATION.
         invalid_prefix      = 1
         invalid_object_type = 2
         OTHERS              = 3.
-    IF sy-subrc <> 0.
+    IF sy-subrc <> 0 OR lv_namespace = '/0CUST/'.
       RETURN.
     ENDIF.
 


### PR DESCRIPTION
For Z objects function TRINT_GET_NAMESPACE returns /0CUST/ namespace