### PR TITLE
Check 89: Remove Version Parameter in RFC-Function Module

### DIFF
--- a/src/utils/zaoc_wrapper.fugr.xml
+++ b/src/utils/zaoc_wrapper.fugr.xml
@@ -26,12 +26,6 @@
        <TYP>LXEOBJNAME</TYP>
       </RSIMP>
       <RSIMP>
-       <PARAMETER>VERSION</PARAMETER>
-       <DEFAULT>&apos;&apos;</DEFAULT>
-       <OPTIONAL>X</OPTIONAL>
-       <TYP>NUMC4</TYP>
-      </RSIMP>
-      <RSIMP>
        <PARAMETER>SH_EMPTY</PARAMETER>
        <DEFAULT>&apos;&apos;</DEFAULT>
        <OPTIONAL>X</OPTIONAL>
@@ -71,11 +65,6 @@
        <PARAMETER>OBJNAME</PARAMETER>
        <KIND>P</KIND>
        <STEXT>Name of Translation Object</STEXT>
-      </RSFDO>
-      <RSFDO>
-       <PARAMETER>VERSION</PARAMETER>
-       <KIND>P</KIND>
-       <STEXT>Count parameters</STEXT>
       </RSFDO>
       <RSFDO>
        <PARAMETER>SH_EMPTY</PARAMETER>

--- a/src/utils/zaoc_wrapper.fugr.zaoc_obj_doku_get_xstring_rfc.abap
+++ b/src/utils/zaoc_wrapper.fugr.zaoc_obj_doku_get_xstring_rfc.abap
@@ -5,7 +5,6 @@ FUNCTION zaoc_obj_doku_get_xstring_rfc.
 *"     VALUE(LANG) TYPE  SPRAS
 *"     VALUE(OBJTYPE) TYPE  LXEOBJTYPE
 *"     VALUE(OBJNAME) TYPE  LXEOBJNAME
-*"     VALUE(VERSION) TYPE  NUMC4 DEFAULT ''
 *"     VALUE(SH_EMPTY) TYPE  CHAR1 DEFAULT ''
 *"  EXPORTING
 *"     VALUE(HEADER) TYPE  THEAD
@@ -19,7 +18,6 @@ FUNCTION zaoc_obj_doku_get_xstring_rfc.
       lang     = lang
       objtype  = objtype
       objname  = objname
-      version  = version
       sh_empty = sh_empty
     IMPORTING
       header   = header


### PR DESCRIPTION
Parameter is never supplied and optional below 750, but does not exist above 750

closes #1007 

Should be tested  for 702 (is the `version` parameter optional there as well?)