### PR TITLE
Check 069 - determine method types

### DIFF
--- a/src/checks/zcl_aoc_check_69.clas.abap
+++ b/src/checks/zcl_aoc_check_69.clas.abap
@@ -1284,10 +1284,10 @@ CLASS zcl_aoc_check_69 IMPLEMENTATION.
     DATA:
       lv_lines TYPE i.
 
-    lv_lines = lines( rt_tokens ).
-
     INSERT LINES OF ref_scan->tokens FROM statement_wa-from
       TO statement_wa-to INTO TABLE rt_tokens.
+
+    lv_lines = lines( rt_tokens ).
 
     CALL FUNCTION 'RS_QUALIFY_ABAP_TOKENS_STR'
       EXPORTING


### PR DESCRIPTION
There was an error in PR #1023.

The parameters of a method were detected as locals
![image](https://user-images.githubusercontent.com/56556686/116988055-22aefb00-acd0-11eb-8ad8-2bdf70857035.png)
