### PR TITLE
infinite loop fix

### DIFF
--- a/src/parsing/zcl_aoc_boolean.clas.abap
+++ b/src/parsing/zcl_aoc_boolean.clas.abap
@@ -328,10 +328,9 @@ CLASS ZCL_AOC_BOOLEAN IMPLEMENTATION.
           lv_restart TYPE abap_bool,
           lv_index   TYPE i.
 
-    lt_tokens = io_tokens->get_tokens( ).
-
     DO.
       lv_restart = abap_false.
+      lt_tokens = io_tokens->get_tokens( ).
       LOOP AT lt_tokens INTO ls_token.
         lv_index = sy-tabix.
 


### PR DESCRIPTION
infinite loop fix #1024 
There is infinite loop in method `remove_method_calls` caused by changing mt_tokens in method `replace`