### PR TITLE
modify corresponding scan message

### DIFF
--- a/docs/_checks/45.md
+++ b/docs/_checks/45.md
@@ -164,7 +164,12 @@ can be replaced with
 ```abap
 struc2 = CORRESPONDING #( struc1 ).
 ```
-Warning: `struc2` will be initialized before the move.
+
+Warning: `struc2` will be initialized before the move. On ABAP releases from 740sp08 onwards, the `BASE` addition should be used to avoid this and to keep the statement in line with the functionality of  `MOVE-CORRESPONDING`:
+
+```abap
+struc2 = CORRESPONDING #( BASE( struc2 ) struc1 ).
+```
 
 see documentation: [https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abenconstructor_expr_corresponding.htm](https://help.sap.com/doc/abapdocu_752_index_htm/7.52/en-US/abenconstructor_expr_corresponding.htm)
 

--- a/src/checks/zcl_aoc_check_45.clas.abap
+++ b/src/checks/zcl_aoc_check_45.clas.abap
@@ -25,6 +25,9 @@ CLASS zcl_aoc_check_45 DEFINITION
     METHODS support_740sp02
       RETURNING
         VALUE(rv_supported) TYPE abap_bool .
+    METHODS support_740sp08
+      RETURNING
+        VALUE(rv_supported) TYPE abap_bool .
   PRIVATE SECTION.
 
     DATA mv_lines TYPE flag .
@@ -122,7 +125,11 @@ CLASS zcl_aoc_check_45 IMPLEMENTATION.
       ELSEIF mv_corresponding = abap_true
           AND <ls_statement>-str CP 'MOVE-CORRESPONDING * TO *'
           AND support_740sp02( ) = abap_true.
-        lv_code = '011'.
+        IF support_740sp08( ) = abap_true.
+          lv_code = '013'.
+        ELSE.
+          lv_code = '011'.
+        ENDIF.
       ELSEIF mv_line_exists = abap_true
           AND <ls_statement>-str CP 'READ TABLE * TRANSPORTING NO FIELDS*'
           AND NOT <ls_statement>-str CP '* BINARY SEARCH*'
@@ -260,11 +267,15 @@ CLASS zcl_aoc_check_45 IMPLEMENTATION.
 
     insert_scimessage(
         iv_code = '011'
-        iv_text = 'Use corresponding #( )'(m11) ).
+        iv_text = 'Use corresponding #( ) if source is initial'(m11) ).
 
     insert_scimessage(
         iv_code = '012'
         iv_text = 'Use line_exists( )'(m12) ).
+
+    insert_scimessage(
+        iv_code = '013'
+        iv_text = 'Use corresponding #( base( source ) target )'(m13) ).
 
   ENDMETHOD.
 
@@ -336,8 +347,11 @@ CLASS zcl_aoc_check_45 IMPLEMENTATION.
 
 
   METHOD support_740sp02.
-
-    rv_supported = lcl_supported=>support_740sp02( ).
-
+    rv_supported = lcl_supported=>is_740sp02_supported( ).
   ENDMETHOD.
+
+  METHOD support_740sp08.
+    rv_supported = lcl_supported=>is_740sp08_supported( ).
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_45.clas.locals_def.abap
+++ b/src/checks/zcl_aoc_check_45.clas.locals_def.abap
@@ -1,0 +1,16 @@
+CLASS lcl_supported DEFINITION FINAL.
+
+  PUBLIC SECTION.
+    CLASS-METHODS is_740sp02_supported
+      RETURNING
+        VALUE(rv_supported) TYPE abap_bool.
+
+    CLASS-METHODS is_740sp08_supported
+      RETURNING
+        VALUE(rv_supported) TYPE abap_bool.
+
+  PRIVATE SECTION.
+    CLASS-DATA gv_740sp02 TYPE abap_bool VALUE abap_undefined.
+    CLASS-DATA gv_740sp08 TYPE abap_bool VALUE abap_undefined.
+
+ENDCLASS.

--- a/src/checks/zcl_aoc_check_45.clas.locals_imp.abap
+++ b/src/checks/zcl_aoc_check_45.clas.locals_imp.abap
@@ -1,29 +1,6 @@
-
-
-CLASS lcl_supported DEFINITION FINAL.
-
-  PUBLIC SECTION.
-    CLASS-METHODS: support_740sp02
-      RETURNING
-        VALUE(rv_supported) TYPE abap_bool.
-
-  PRIVATE SECTION.
-    CLASS-DATA gv_executed TYPE abap_bool.
-    CLASS-DATA gv_740sp02 TYPE abap_bool.
-    CLASS-METHODS: find_supported.
-
-ENDCLASS.
-
 CLASS lcl_supported IMPLEMENTATION.
 
-  METHOD support_740sp02.
-
-    find_supported( ).
-    rv_supported = gv_740sp02.
-
-  ENDMETHOD.
-
-  METHOD find_supported.
+  METHOD is_740sp02_supported.
 
     DATA: lt_itab  TYPE STANDARD TABLE OF string,
           lv_mess  TYPE string,
@@ -32,8 +9,8 @@ CLASS lcl_supported IMPLEMENTATION.
           lv_code  TYPE string,
           lv_wrd   TYPE string.
 
-
-    IF gv_executed = abap_true.
+    IF gv_740sp02 <> abap_undefined.
+      rv_supported = gv_740sp02.
       RETURN.
     ENDIF.
 
@@ -49,13 +26,41 @@ CLASS lcl_supported IMPLEMENTATION.
       LINE lv_lin
       WORD lv_wrd
       DIRECTORY ENTRY ls_trdir.
-    IF sy-subrc = 0.
-* all supported in 740SP02
-      gv_740sp02 = abap_true.
+
+    gv_740sp02 = boolc( sy-subrc = 0 ).
+    rv_supported = gv_740sp02.
+  ENDMETHOD.
+
+
+  METHOD is_740sp08_supported.
+
+    DATA: lt_itab  TYPE STANDARD TABLE OF string,
+          lv_mess  TYPE string,
+          lv_lin   TYPE i,
+          ls_trdir TYPE trdir,
+          lv_code  TYPE string,
+          lv_wrd   TYPE string.
+
+    IF gv_740sp08 <> abap_undefined.
+      rv_supported = gv_740sp08.
+      RETURN.
     ENDIF.
 
-    gv_executed = abap_true.
+    lv_code = 'REPORT zfoobar.' ##NO_TEXT.
+    APPEND lv_code TO lt_itab.
+    lv_code = 'DATA(ok) = xsdbool( sy-subrc = 0 ).' ##NO_TEXT.
+    APPEND lv_code TO lt_itab.
 
+    ls_trdir-uccheck = abap_true.
+
+    SYNTAX-CHECK FOR lt_itab
+      MESSAGE lv_mess
+      LINE lv_lin
+      WORD lv_wrd
+      DIRECTORY ENTRY ls_trdir.
+
+    gv_740sp08 = boolc( sy-subrc = 0 ).
+    rv_supported = gv_740sp08.
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_45.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_45.clas.testclasses.abap
@@ -336,11 +336,20 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test011_01.
 
+    DATA lv_expected TYPE sci_errc.
+
+    IF mo_check->support_740sp08( ) = abap_true.
+      lv_expected = '013'.
+    ELSE.
+      lv_expected = '011'.
+    ENDIF.
+
+
     _code 'MOVE-CORRESPONDING foo TO bar.'.
 
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 
-    cl_abap_unit_assert=>assert_equals( exp = '011'
+    cl_abap_unit_assert=>assert_equals( exp = lv_expected
                                         act = ms_result-code ).
 
   ENDMETHOD.

--- a/src/checks/zcl_aoc_check_45.clas.xml
+++ b/src/checks/zcl_aoc_check_45.clas.xml
@@ -77,7 +77,7 @@
     <item>
      <ID>I</ID>
      <KEY>M11</KEY>
-     <ENTRY>Use corresponding #( )</ENTRY>
+     <ENTRY>Use corresponding #( ) if source is initial</ENTRY>
      <LENGTH>44</LENGTH>
     </item>
     <item>
@@ -85,6 +85,12 @@
      <KEY>M12</KEY>
      <ENTRY>Use line_exists( )</ENTRY>
      <LENGTH>28</LENGTH>
+    </item>
+    <item>
+     <ID>I</ID>
+     <KEY>M13</KEY>
+     <ENTRY>Use corresponding #( base( source ) target )</ENTRY>
+     <LENGTH>88</LENGTH>
     </item>
    </TPOOL>
    <LINES>


### PR DESCRIPTION
if version >= v740sp08, use BASE with CORRESPONDING

if using CORRESPONDING without BASE addition, it will only have the same effect as MOVE-CORRESPONDING if the target is initial

change scan message to reflect this

closes #1019