### PR TITLE
OBJECTS_OBJREF_NOT_ASSIGNED fix for SAP_BASIS 755

### DIFF
--- a/src/checks/zcl_aoc_check_69.clas.abap
+++ b/src/checks/zcl_aoc_check_69.clas.abap
@@ -227,6 +227,7 @@ CLASS zcl_aoc_check_69 IMPLEMENTATION.
       ENDIF.
     ENDIF.
 
+    cl_abap_compiler=>clear_cache( ).
     CREATE OBJECT mo_stack.
     mo_compiler = cl_abap_compiler=>create( program_name ).
 


### PR DESCRIPTION
**This is a behavior of SAP_BASIS Release 755, SP 2**
Other Versions of SAP_BASIS might not have this issue. We checked with 753 and it was fine.

The method CL_ABAP_COMPILER→GET_SYMBOL_ENTRY( ) uses a caching table (SYMBOL_CACHE).
Witch is filled on first run, but with an initial type {O:2220*\CLASS=CL_ABAP_COMP_DATA}-TYPE = {O:INITIAL}
![image2022-1-28_9-50-47](https://user-images.githubusercontent.com/20706603/152543093-5b4cf633-6d84-48be-a1a7-437a2615349b.png)

so the check will result in an OBJECTS_OBJREF_NOT_ASSIGNED dump.
![image2022-1-28_13-6-0](https://user-images.githubusercontent.com/20706603/152543046-d8c1e56e-c27b-475d-aa1b-9295f4ea2168.png)

On a 2nd run thorugh the check symbol_entry gets reassigned and the check works.
![image2022-1-28_13-8-53](https://user-images.githubusercontent.com/20706603/152543081-c4eb6e62-b4f0-4666-a870-fa4c3134583b.png)
![image2022-1-28_14-8-45](https://user-images.githubusercontent.com/20706603/152543198-e53d1b40-744e-49c9-a027-467e3077cbd0.png)

By resetting the Cache befor the first run through the issue gets resolved:
`cl_abap_compiler=>clear_cache( ).`
