### PR TITLE
Check 06: Ignore FM and Function Pool definitions

### DIFF
--- a/src/checks/zcl_aoc_check_06.clas.abap
+++ b/src/checks/zcl_aoc_check_06.clas.abap
@@ -215,6 +215,12 @@ CLASS zcl_aoc_check_06 IMPLEMENTATION.
 
       LOOP AT lt_code ASSIGNING <lv_code>.
         lv_row = sy-tabix.
+
+        IF lv_row = 1 AND <lv_code>(8) = 'FUNCTION'.
+          " Ignore Function Module and Function Pool definitions
+          CONTINUE.
+        ENDIF.
+
         READ TABLE lt_pretty INDEX lv_row ASSIGNING <lv_pretty>.
         ASSERT sy-subrc = 0.
 

--- a/src/checks/zcl_aoc_check_06.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_06.clas.testclasses.abap
@@ -30,7 +30,9 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test001_10 FOR TESTING,
       test001_11 FOR TESTING,
       test001_12 FOR TESTING,
-      test001_13 FOR TESTING.
+      test001_13 FOR TESTING,
+      test001_14 FOR TESTING,
+      test001_15 FOR TESTING.
 
 ENDCLASS.       "lcl_Test
 
@@ -226,5 +228,30 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_initial( ms_result ).
 
   ENDMETHOD.                    "test001_13
+
+  METHOD test001_14.
+* ===========
+
+    _code 'FUNCTION-POOL SOME_FUNCTION'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+
+  ENDMETHOD.                    "test001_14
+
+  METHOD test001_15.
+* ===========
+
+    _code 'FUNCTION SOME_FUNCTION'.
+    _code 'data(var) = ''value'''.
+    _code 'ENDFUNCTION.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_equals( exp = '001'
+                                        act = ms_result-code ).
+
+  ENDMETHOD.                    "test001_15
 
 ENDCLASS.       "lcl_Test


### PR DESCRIPTION
Fixes remaining issues mentioned in https://github.com/larshp/abapOpenChecks/issues/897.

Ignores the first line of function modules and function pool definitions due to auto formatting that gets applied.