### PR TITLE
AOC06: empty first line in include leads to dump

### DIFF
--- a/src/checks/zcl_aoc_check_06.clas.abap
+++ b/src/checks/zcl_aoc_check_06.clas.abap
@@ -218,7 +218,7 @@ CLASS zcl_aoc_check_06 IMPLEMENTATION.
       LOOP AT lt_code ASSIGNING <lv_code>.
         lv_row = sy-tabix.
 
-        IF lv_row = 1 AND <lv_code>(8) = 'FUNCTION'.
+        IF lv_row = 1 AND <lv_code> CP 'FUNCTION*'.
           " Ignore Function Module and Function Pool definitions
           CONTINUE.
         ENDIF.

--- a/src/checks/zcl_aoc_check_06.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_06.clas.testclasses.abap
@@ -32,7 +32,8 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test001_12 FOR TESTING,
       test001_13 FOR TESTING,
       test001_14 FOR TESTING,
-      test001_15 FOR TESTING.
+      test001_15 FOR TESTING,
+      test001_16 FOR TESTING.
 
 ENDCLASS.       "lcl_Test
 
@@ -254,4 +255,15 @@ CLASS ltcl_test IMPLEMENTATION.
 
   ENDMETHOD.                    "test001_15
 
+  METHOD test001_16.
+*  ===========
+    
+    _code ''.
+    _code 'CLASS lcl_test IMPLEMENTATION'.
+    _code 'ENDCLASS.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+  ENDMETHOD.                    " test001_16
 ENDCLASS.       "lcl_Test


### PR DESCRIPTION
#1106 introduced an issue with empty first lines that lead to an uncaught CX_SY_RANGE_OUT_OF_BOUNDS.

In our case it analyzed an include that had an empty first line:
![grafik](https://github.com/larshp/abapOpenChecks/assets/9104198/f6050090-ecf1-4c83-ae7f-4eb06ee5f790)

Searching via pattern instead of accessing the first 8 character of the string solves this.