### PR TITLE
Check 34 ignores single line comments

### DIFF
--- a/src/checks/zcl_aoc_check_34.clas.abap
+++ b/src/checks/zcl_aoc_check_34.clas.abap
@@ -76,7 +76,7 @@ CLASS ZCL_AOC_CHECK_34 IMPLEMENTATION.
           lv_start = 0.
         WHEN OTHERS.
           IF <ls_statement>-type = io_scan->gc_statement-comment.
-            lv_comment_lines = lv_comment_lines + <ls_statement>-to - <ls_statement>-from.
+            lv_comment_lines = lv_comment_lines + <ls_statement>-to - <ls_statement>-from + 1.
           ENDIF.
       ENDCASE.
 

--- a/src/checks/zcl_aoc_check_34.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_34.clas.testclasses.abap
@@ -154,7 +154,6 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD test001_06.
 * ===========
-  
     mo_check->mv_incl_comments = abap_false.
     mo_check->mv_lines = 5.
 

--- a/src/checks/zcl_aoc_check_34.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_34.clas.testclasses.abap
@@ -24,7 +24,8 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test001_02 FOR TESTING,
       test001_03 FOR TESTING,
       test001_04 FOR TESTING RAISING cx_static_check,
-      test001_05 FOR TESTING RAISING cx_static_check.
+      test001_05 FOR TESTING RAISING cx_static_check,
+      test001_06 FOR TESTING RAISING cx_static_check.
 
 ENDCLASS.       "lcl_Test
 
@@ -151,4 +152,24 @@ CLASS ltcl_test IMPLEMENTATION.
 
   ENDMETHOD.
 
+  METHOD test001_06.
+* ===========
+  
+    mo_check->mv_incl_comments = abap_false.
+    mo_check->mv_lines = 5.
+
+    _code 'CASE lv_foo.'.
+    _code '  WHEN ''bar''.'.
+    _code '    WRITE: ''hello''.'.
+    _code '    WRITE: ''hello''.'.
+    _code '*.'.
+    _code '    WRITE: ''hello''.'.
+    _code '    WRITE: ''hello''.'.
+    _code 'ENDCASE.'.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result ).
+  
+  ENDMETHOD.
 ENDCLASS.       "lcl_Test

--- a/src/checks/zcl_aoc_check_34.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_34.clas.testclasses.abap
@@ -169,6 +169,5 @@ CLASS ltcl_test IMPLEMENTATION.
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 
     cl_abap_unit_assert=>assert_initial( ms_result ).
-  
   ENDMETHOD.
 ENDCLASS.       "lcl_Test


### PR DESCRIPTION
When ignoring comments for check 34 the current logic always counts 1 line less than there is in the code.

`lv_comment_lines = lv_comment_lines + <ls_statement>-to`

Example: Single line comment starts and ends in line 43 -> 0 comments