### PR TITLE
Change documentation links from master to main

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -6,9 +6,9 @@
 {% include header.html %}
 <div class="content">
 <h1>{% if page.cNumber %}{{ page.cNumber }} - {{ page.title }}{% else %}{{ page.title }}{% endif %}</h1>
-<small><a href="{{ site.github.repository_url }}/tree/master/docs/{{ page.path }}">{% octicon pencil %} Improve this page</a></small>
+<small><a href="{{ site.github.repository_url }}/tree/main/docs/{{ page.path }}">{% octicon pencil %} Improve this page</a></small>
 {% if page.rfc %}<br><img src="/img/rfc.png" title="RFC-based"><small> RFC enabled</small>{% endif %}
-{% if page.cNumber %}<br><a href="https://github.com/larshp/abapOpenChecks/blob/master/src/checks/zcl_aoc_{{ page.cNumber | downcase }}.clas.abap">{% octicon code %} <tt>CODE</tt></a>{% endif %}
+{% if page.cNumber %}<br><a href="https://github.com/larshp/abapOpenChecks/blob/main/src/checks/zcl_aoc_{{ page.cNumber | downcase }}.clas.abap">{% octicon code %} <tt>CODE</tt></a>{% endif %}
 {{ content }}
 </div>
 </div>


### PR DESCRIPTION
The links in the documentation still point to the `master` branch instead of the `main` branch. This works, but always displays the message "Branch master was renamed to main.".

This pull request should fix both the "Improve this page" and the "CODE" button from the check pages. 