### PR TITLE
CHECK_102: Correctly classify usage of MOVE

### DIFF
--- a/src/checks/zcl_aoc_scan.clas.abap
+++ b/src/checks/zcl_aoc_scan.clas.abap
@@ -79,6 +79,8 @@ CLASS zcl_aoc_scan DEFINITION
                  like              TYPE string VALUE 'LIKE',
                  call              TYPE string VALUE 'CALL',
                  function          TYPE string VALUE 'FUNCTION',
+                 move              TYPE string VALUE 'MOVE',
+                 to                TYPE string VALUE 'TO',
                END OF gc_keyword.
 
     TYPES:

--- a/src/utils/zcl_aoc_sy_variable_analyzer.clas.abap
+++ b/src/utils/zcl_aoc_sy_variable_analyzer.clas.abap
@@ -95,7 +95,7 @@ CLASS zcl_aoc_sy_variable_analyzer IMPLEMENTATION.
       RETURN.
     ENDIF.
 
-    ASSIGN mo_scan->tokens[ iv_index_token - 1 ] TO FIELD-SYMBOL(<ls_token_before_sysid>).
+    ASSIGN mo_scan->tokens[ iv_index_token - 1 ] TO FIELD-SYMBOL(<ls_token_before_sy_var>).
     ASSIGN mo_scan->tokens[ is_statement-from ] TO FIELD-SYMBOL(<ls_first_token_of_statement>).
 
     CASE <ls_first_token_of_statement>-str.
@@ -124,7 +124,7 @@ CLASS zcl_aoc_sy_variable_analyzer IMPLEMENTATION.
           OR zcl_aoc_scan=>gc_keyword-data
           OR zcl_aoc_scan=>gc_keyword-class_data.
 
-        CASE <ls_token_before_sysid>-str.
+        CASE <ls_token_before_sy_var>-str.
           WHEN zcl_aoc_scan=>gc_keyword-default.
             rv_usage_kind = gc_usage_kind-as_default_value.
           WHEN OTHERS.
@@ -137,8 +137,20 @@ CLASS zcl_aoc_sy_variable_analyzer IMPLEMENTATION.
         ELSE.
           rv_usage_kind = gc_usage_kind-usage_uncategorized.
         ENDIF.
+      WHEN zcl_aoc_scan=>gc_keyword-move.
+        IF <ls_token_before_sy_var>-str = zcl_aoc_scan=>gc_keyword-to.
+          rv_usage_kind = gc_usage_kind-overridden.
+        ELSE.
+          ASSIGN mo_scan->tokens[ iv_index_token + 1 ] TO FIELD-SYMBOL(<ls_token_after_sy_var>).
+
+          IF <ls_token_after_sy_var>-str = zcl_aoc_scan=>gc_keyword-to.
+            rv_usage_kind = gc_usage_kind-assigned_to_variable.
+          ELSE.
+            rv_usage_kind = gc_usage_kind-usage_uncategorized.
+          ENDIF.
+        ENDIF.
       WHEN OTHERS.
-        IF <ls_token_before_sysid>-str        = '='
+        IF <ls_token_before_sy_var>-str            = '='
             AND iv_index_token - is_statement-from = 2.
           rv_usage_kind = gc_usage_kind-assigned_to_variable.
         ELSE.

--- a/src/utils/zcl_aoc_sy_variable_analyzer.clas.testclasses.abap
+++ b/src/utils/zcl_aoc_sy_variable_analyzer.clas.testclasses.abap
@@ -86,6 +86,10 @@ CLASS ltcl_test DEFINITION
     METHODS multiple_results FOR TESTING RAISING cx_static_check.
 
     METHODS call_function FOR TESTING RAISING cx_static_check.
+
+    METHODS move_01 FOR TESTING RAISING cx_static_check.
+
+    METHODS move_02 FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 
@@ -607,6 +611,32 @@ CLASS ltcl_test IMPLEMENTATION.
     assert_single_result( VALUE #( statement_index = 1
                                    token_index     = 7
                                    usage_kind      = gc_usage_kind-in_function_module_call ) ).
+  ENDMETHOD.
+
+  METHOD move_01.
+    " Given
+    _code `MOVE sy-sysid TO DATA(lv_sysid).`.
+
+    " When
+    analyze_variables( ).
+
+    " Then
+    assert_single_result( VALUE #( statement_index = 1
+                                   token_index     = 2
+                                   usage_kind      = gc_usage_kind-assigned_to_variable ) ).
+  ENDMETHOD.
+
+  METHOD move_02.
+    " Given
+    _code `MOVE 'DEV' TO sy-sysid.`.
+
+    " When
+    analyze_variables( ).
+
+    " Then
+    assert_single_result( VALUE #( statement_index = 1
+                                   token_index     = 4
+                                   usage_kind      = gc_usage_kind-overridden ) ).
   ENDMETHOD.
 
 ENDCLASS.


### PR DESCRIPTION
This pull request adds capabilities to the SY variable analyzer to correctly classify the use of MOVE as either assigning to a variable or overriding the original value.