### PR TITLE
Check-47: DESTINATION parameter not recognized any more #1148

### DIFF
--- a/src/checks/zcl_aoc_check_47.clas.abap
+++ b/src/checks/zcl_aoc_check_47.clas.abap
@@ -67,7 +67,7 @@ CLASS ZCL_AOC_CHECK_47 IMPLEMENTATION.
       " This could have also been checked by a regex (when followed by or lead by '=' it is a parameter)
       " but this would require a pretty high SAP_BASIS release.
       IF lv_statement CP 'CALL FUNCTION *'
-          AND lv_fourth    EQ 'DESTINATION'
+          AND lv_fourth    = 'DESTINATION'
           AND lv_statement NP '* EXCEPTIONS * MESSAGE *'
           AND lv_statement NP '* DESTINATION ''NONE'' *'.
         lv_include = io_scan->get_include( <ls_statement>-level ).

--- a/src/checks/zcl_aoc_check_47.clas.abap
+++ b/src/checks/zcl_aoc_check_47.clas.abap
@@ -25,6 +25,8 @@ CLASS ZCL_AOC_CHECK_47 IMPLEMENTATION.
 * MIT License
 
     DATA: lv_include   TYPE sobj_name,
+          lv_count     TYPE i,
+          lv_fourth    TYPE string,
           lv_statement TYPE string.
 
     FIELD-SYMBOLS: <ls_statement> LIKE LINE OF io_scan->statements,
@@ -39,11 +41,19 @@ CLASS ZCL_AOC_CHECK_47 IMPLEMENTATION.
         AND type <> io_scan->gc_statement-pragma.
 
       CLEAR lv_statement.
+      CLEAR lv_fourth.
+      lv_count = 0.
 
       LOOP AT io_scan->tokens ASSIGNING <ls_token>
           FROM <ls_statement>-from TO <ls_statement>-to
           WHERE type = io_scan->gc_token-identifier
           OR type = io_scan->gc_token-literal.
+        lv_count = lv_count + 1.
+
+        IF lv_count = 4.
+          lv_fourth = <ls_token>-str.
+        ENDIF.
+
         IF lv_statement IS INITIAL.
           lv_statement = <ls_token>-str.
         ELSE.
@@ -52,7 +62,12 @@ CLASS ZCL_AOC_CHECK_47 IMPLEMENTATION.
         ENDIF.
       ENDLOOP.
 
-      IF lv_statement CP 'CALL FUNCTION * DESTINATION *'
+      " The keyword DESTINATION needs to be checked only at fourth position
+      " as a parameter could also be named like the keyword (e.g. module GET_PRINT_PARAMETERS).
+      " This could have also been checked by a regex (when followed by or lead by '=' it is a parameter)
+      " but this would require a pretty high SAP_BASIS release.
+      IF lv_statement CP 'CALL FUNCTION *'
+          AND lv_fourth    EQ 'DESTINATION'
           AND lv_statement NP '* EXCEPTIONS * MESSAGE *'
           AND lv_statement NP '* DESTINATION ''NONE'' *'.
         lv_include = io_scan->get_include( <ls_statement>-level ).


### PR DESCRIPTION
I did not see the unit test failing before. Reverted most of changes and still left the restriction for CALL FUNCTION in place. Added a comment on why it is solved this way.