### PR TITLE
Documentation for check 60

### DIFF
--- a/docs/_checks/60.md
+++ b/docs/_checks/60.md
@@ -5,7 +5,7 @@ rfc: true
 index: 60
 ---
 
-See SAP styleguides for Clean ABAP: [Use | to assemble text](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#use--to-assemble-text)
+See SAP styleguides for Clean ABAP: [Use \| to assemble text](https://github.com/SAP/styleguides/blob/master/clean-abap/CleanABAP.md#use--to-assemble-text)
 
 Examples:
 


### PR DESCRIPTION
The formatting is broken on https://docs.abapopenchecks.org/checks/60/ even though it looks correct in the preview on GitHub. I hope that an escape character will help.

![image](https://github.com/user-attachments/assets/976ad224-959b-4315-b87c-2e838ced441d)
