### PR TITLE
Add stable checksum calculation to checks 57 and 76

### DIFF
--- a/src/checks/zcl_aoc_check_57.clas.abap
+++ b/src/checks/zcl_aoc_check_57.clas.abap
@@ -35,6 +35,7 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
 * MIT License
 
     DATA: lt_statements TYPE zcl_aoc_scan=>ty_statements,
+          lv_position   LIKE sy-tabix,
           lv_index      TYPE i,
           lv_code       TYPE sci_errc,
           ls_prev       LIKE LINE OF lt_statements.
@@ -49,6 +50,7 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
     lt_statements = io_scan->build_statements( ).
 
     LOOP AT lt_statements ASSIGNING <ls_statement>.
+      lv_position = sy-tabix.
       lv_index = sy-tabix - 1.
       CLEAR ls_prev.
       READ TABLE lt_statements INDEX lv_index INTO ls_prev. "#EC CI_SUBRC
@@ -84,6 +86,7 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
       ENDIF.
 
       inform( p_sub_obj_name = <ls_statement>-include
+              p_position     = lv_position
               p_line         = <ls_statement>-start-row
               p_kind         = mv_errty
               p_test         = myname
@@ -104,6 +107,7 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
     attributes_ok  = abap_true.
 
     enable_rfc( ).
+    enable_checksum( ).
 
     mv_into    = abap_true.
     mv_raising = abap_true.

--- a/src/checks/zcl_aoc_check_76.clas.abap
+++ b/src/checks/zcl_aoc_check_76.clas.abap
@@ -43,6 +43,7 @@ CLASS ZCL_AOC_CHECK_76 IMPLEMENTATION.
 * MIT License
 
     DATA: lv_include             TYPE sobj_name,
+          lv_position            LIKE sy-tabix,
           ln_prev_token          TYPE i,
           ln_next_token          TYPE i,
           lf_relevant_join_found TYPE abap_bool,
@@ -62,6 +63,8 @@ CLASS ZCL_AOC_CHECK_76 IMPLEMENTATION.
 
 
     LOOP AT io_scan->statements ASSIGNING <ls_statement>.
+
+      lv_position = sy-tabix.
 
       READ TABLE io_scan->tokens ASSIGNING <ls_token> INDEX <ls_statement>-from.
       IF sy-subrc <> 0.
@@ -136,6 +139,7 @@ CLASS ZCL_AOC_CHECK_76 IMPLEMENTATION.
         lv_include = io_scan->get_include( <ls_statement>-level ).
 
         inform( p_sub_obj_name = lv_include
+                p_position     = lv_position
                 p_line         = ln_line
                 p_column       = ln_column
                 p_kind         = mv_errty

--- a/src/checks/zcl_aoc_check_76.clas.abap
+++ b/src/checks/zcl_aoc_check_76.clas.abap
@@ -163,6 +163,7 @@ CLASS ZCL_AOC_CHECK_76 IMPLEMENTATION.
     attributes_ok  = abap_true.
 
     enable_rfc( ).
+    enable_checksum( ).
 
     insert_scimessage(
         iv_code = '001'

--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -311,7 +311,7 @@ CLASS ZCL_AOC_SUPER IMPLEMENTATION.
 
     READ TABLE ref_scan->statements INDEX iv_position  INTO ls_statement.
 
-    IF sy-subrc <> 0 OR ls_statement-type = 'P' OR ls_statement-type = 'S' OR ls_statement-type = 'G'.
+    IF sy-subrc <> 0.
       set_uses_checksum( abap_false ).
     ELSE.
 


### PR DESCRIPTION
Add stable checksum calculation to checks 57 and 76. Fixes https://github.com/larshp/abapOpenChecks/issues/1162