### PR TITLE
Correct position for checksum calculation in check 57

### DIFF
--- a/src/checks/zcl_aoc_check_57.clas.abap
+++ b/src/checks/zcl_aoc_check_57.clas.abap
@@ -35,7 +35,6 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
 * MIT License
 
     DATA: lt_statements TYPE zcl_aoc_scan=>ty_statements,
-          lv_position   LIKE sy-tabix,
           lv_index      TYPE i,
           lv_code       TYPE sci_errc,
           ls_prev       LIKE LINE OF lt_statements.
@@ -50,7 +49,6 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
     lt_statements = io_scan->build_statements( ).
 
     LOOP AT lt_statements ASSIGNING <ls_statement>.
-      lv_position = sy-tabix.
       lv_index = sy-tabix - 1.
       CLEAR ls_prev.
       READ TABLE lt_statements INDEX lv_index INTO ls_prev. "#EC CI_SUBRC
@@ -86,7 +84,7 @@ CLASS ZCL_AOC_CHECK_57 IMPLEMENTATION.
       ENDIF.
 
       inform( p_sub_obj_name = <ls_statement>-include
-              p_position     = lv_position
+              p_position     = <ls_statement>-index
               p_line         = <ls_statement>-start-row
               p_kind         = mv_errty
               p_test         = myname


### PR DESCRIPTION
Check 57 is based on the statement table io_scan->build_statements( ) instead of io_scan->statements. Therefore we cannot use the index of the line in the table returned by build_statements( ) but we need to use the field "index" in that table to calculate the checksum.

Fixes in issue introduced with https://github.com/larshp/abapOpenChecks/pull/1163 that enabled checksum calculation (https://github.com/larshp/abapOpenChecks/issues/1162).