### PR TITLE
Various checks: exempt AMDP

### DIFF
--- a/src/checks/zcl_aoc_check_08.clas.abap
+++ b/src/checks/zcl_aoc_check_08.clas.abap
@@ -49,9 +49,6 @@ CLASS zcl_aoc_check_08 DEFINITION
       RETURNING
         VALUE(rv_old) TYPE abap_bool .
   PRIVATE SECTION.
-    METHODS is_class_amdp
-      RETURNING
-        VALUE(rv_class_amdp) TYPE abap_bool.
 
 ENDCLASS.
 
@@ -70,15 +67,14 @@ CLASS zcl_aoc_check_08 IMPLEMENTATION.
           lv_include    TYPE sobj_name,
           lv_code       TYPE sci_errc,
           lv_token      TYPE string,
-          lv_statement  TYPE string,
-          lv_is_amdp    TYPE abap_bool.
+          lv_statement  TYPE string.
 
     FIELD-SYMBOLS: <ls_token>     LIKE LINE OF io_scan->tokens,
                    <ls_statement> LIKE LINE OF io_scan->statements.
 
-    lv_is_amdp = is_class_amdp( ).
 
-    LOOP AT io_scan->statements ASSIGNING <ls_statement>.
+    LOOP AT io_scan->statements ASSIGNING <ls_statement>
+        WHERE type <> io_scan->gc_statement-native_sql.
 
       lv_position = sy-tabix.
       CLEAR lv_statement.
@@ -115,8 +111,7 @@ CLASS zcl_aoc_check_08 IMPLEMENTATION.
       ELSEIF mv_006 = abap_true
           AND ( lv_statement CP '* >< *'
           OR lv_statement CP '* =< *'
-          OR lv_statement CP '* => *' )
-          AND lv_is_amdp = abap_false.
+          OR lv_statement CP '* => *' ).
         lv_code = '006'.
       ELSEIF mv_007 = abap_true AND is_old( lv_statement ) = abap_true.
         lv_code = '007'.
@@ -422,23 +417,5 @@ CLASS zcl_aoc_check_08 IMPLEMENTATION.
 
   ENDMETHOD.
 
-  METHOD is_class_amdp.
-
-    DATA lv_seometarel TYPE seometarel.
-
-    IF object_type = 'CLAS'.
-      SELECT SINGLE clsname
-        FROM seometarel
-        INTO lv_seometarel
-        WHERE clsname = object_name
-        AND refclsname = 'IF_AMDP_MARKER_HDB'
-        AND version = '1'
-        AND reltype = '1'.
-      IF sy-subrc = 0.
-        rv_class_amdp = abap_true.
-      ENDIF.
-    ENDIF.
-
-  ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_08.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_08.clas.testclasses.abap
@@ -209,12 +209,12 @@ CLASS ltcl_test IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD test006_02.
-    mo_check->object_type = 'CLAS'.
-    mo_check->object_name = 'CL_AMDP_HDB_UTIL'.
 
+    _code 'METHOD my_method BY DATABASE PROCEDURE FOR HDB LANGUAGE SQLSCRIPT.'.
     _code 'result = SELECT field1'.
     _code 'FROM schema._SYS_BIC.view_name'.
     _code 'PLACEHOLDER.$$parameter$$ => :input;'.
+    _code 'ENDMETHOD.'.
 
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 
@@ -223,11 +223,11 @@ CLASS ltcl_test IMPLEMENTATION.
   ENDMETHOD.
 
   METHOD test006_03.
-    mo_check->object_type = 'CLAS'.
-    mo_check->object_name = 'CL_AMDP_HDB_UTIL'.
 
-    _code 'CALL "ZCLASS=>GET_DATA" ( result => data );'.
-    _code '"ZCLASS=>GET_DATA" ( result => data );'.
+    _code `METHOD my_method BY DATABASE PROCEDURE FOR HDB LANGUAGE SQLSCRIPT USING zclass=>method_1 zclass=>method_2.`.
+    _code `CALL "ZCLASS=>METHOD_1" ( param1 => 'A', result => data1 );`.
+    _code `"ZCLASS=>METHOD_2" ( result => data );`.
+    _code `ENDMETHOD.`.
 
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 

--- a/src/checks/zcl_aoc_check_15.clas.abap
+++ b/src/checks/zcl_aoc_check_15.clas.abap
@@ -34,7 +34,8 @@ CLASS zcl_aoc_check_15 IMPLEMENTATION.
 
     LOOP AT io_scan->statements ASSIGNING <ls_statement>
         WHERE type <> io_scan->gc_statement-empty
-        AND type <> io_scan->gc_statement-comment.
+        AND type <> io_scan->gc_statement-comment
+        AND type <> io_scan->gc_statement-native_sql.
 
       lv_position = sy-tabix.
       CLEAR lv_statement.
@@ -57,8 +58,7 @@ CLASS zcl_aoc_check_15 IMPLEMENTATION.
           OR lv_statement CP 'CALL SELECTION-SCREEN *'
           OR lv_statement CP 'CALL TRANSACTION *'
           OR lv_statement CP 'CALL TRANSFORMATION *'
-          OR lv_statement CP 'CALL BADI *'
-          OR lv_statement CP 'CALL "*'.         " AMDP method in AMDP method
+          OR lv_statement CP 'CALL BADI *'.
         CONTINUE.
       ELSEIF lv_statement CP 'CALL *'
           OR lv_statement CP 'SYSTEM-CALL *'.

--- a/src/checks/zcl_aoc_check_15.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_15.clas.testclasses.abap
@@ -97,7 +97,9 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD is_amdp_call_ignored.
 
-    _code 'CALL "ZCL_MY_AMDP_CLASS=>ANOTHER_AMDP_METHOD"( iv_input => :iv_input );'.
+    _code `METHOD my_method BY DATABASE PROCEDURE FOR HDB LANGUAGE SQLSCRIPT USING ZCL_MY_AMDP_CLASS=>AMDP_METHOD.`.
+    _code `CALL "ZCL_MY_AMDP_CLASS=>AMDP_METHOD"( iv_input => :iv_input );`.
+    _code `ENDMETHOD.`.
 
     ms_result = zcl_aoc_unit_test=>check( mt_code ).
 

--- a/src/checks/zcl_aoc_check_20.clas.abap
+++ b/src/checks/zcl_aoc_check_20.clas.abap
@@ -24,7 +24,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_20 IMPLEMENTATION.
+CLASS zcl_aoc_check_20 IMPLEMENTATION.
 
 
   METHOD check.
@@ -46,7 +46,8 @@ CLASS ZCL_AOC_CHECK_20 IMPLEMENTATION.
         AND type <> io_scan->gc_statement-comment_in_stmnt
         AND type <> io_scan->gc_statement-empty
         AND type <> io_scan->gc_statement-pragma
-        AND type <> io_scan->gc_statement-macro_definition.
+        AND type <> io_scan->gc_statement-macro_definition
+        AND type <> io_scan->gc_statement-native_sql.
 
       READ TABLE io_scan->tokens ASSIGNING <ls_token> INDEX <ls_statement>-from.
       IF sy-subrc = 0.

--- a/src/checks/zcl_aoc_check_20.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_20.clas.testclasses.abap
@@ -33,6 +33,7 @@ CLASS ltcl_test DEFINITION FOR TESTING
       test001_13 FOR TESTING,
       test001_14 FOR TESTING,
       test001_15 FOR TESTING,
+      test001_16 FOR TESTING,
       test002_01 FOR TESTING,
       test002_02 FOR TESTING.
 
@@ -273,6 +274,20 @@ CLASS ltcl_test IMPLEMENTATION.
     cl_abap_unit_assert=>assert_initial( ms_result-code ).
 
   ENDMETHOD.                    "test001_15
+
+  METHOD test001_16.
+* ===========
+
+    _code `METHOD my_method BY DATABASE PROCEDURE FOR HDB LANGUAGE SQLSCRIPT USING zclass=>method_1 zclass=>method_2.`.
+    _code `  "ZCLASS=>METHOD_1" ( param1 => 'A', result => data1 );`.
+    _code `  "ZCLASS=>METHOD_2" ( param1 => 'A', param2 => 'B', result => data2 );`.
+    _code `ENDMETHOD.`.
+
+    ms_result = zcl_aoc_unit_test=>check( mt_code ).
+
+    cl_abap_unit_assert=>assert_initial( ms_result-code ).
+
+  ENDMETHOD.                    "test001_16
 
   METHOD test002_01.
 * ===========

--- a/src/checks/zcl_aoc_check_41.clas.abap
+++ b/src/checks/zcl_aoc_check_41.clas.abap
@@ -23,7 +23,7 @@ ENDCLASS.
 
 
 
-CLASS ZCL_AOC_CHECK_41 IMPLEMENTATION.
+CLASS zcl_aoc_check_41 IMPLEMENTATION.
 
 
   METHOD check.
@@ -49,6 +49,7 @@ CLASS ZCL_AOC_CHECK_41 IMPLEMENTATION.
         AND type <> io_scan->gc_statement-comment_in_stmnt
         AND type <> io_scan->gc_statement-macro_definition
         AND type <> io_scan->gc_statement-pragma
+        AND type <> io_scan->gc_statement-native_sql
         AND colonrow = 0.
 
       CLEAR lv_prev.


### PR DESCRIPTION
Simpler solution to skip AMDP methods only (not entire class) for checks 8, 15, 20, & 41. Skip processing for statements with type E (native sql).

This also improves changes made in #1166 & #1068