### PR TITLE
Fix error in documentation for check 104

### DIFF
--- a/docs/_checks/104.md
+++ b/docs/_checks/104.md
@@ -1,7 +1,7 @@
 ---
 title: Local existence of function modules called via RFC
 cNumber: CHECK_104
-rfc: true
+rfc: false
 index: 104
 ---
 


### PR DESCRIPTION
I made a small oversight in the documentation last time, sorry