### PR TITLE
CHECK_104: Fix detection of DESTINATION keyword

### DIFF
--- a/src/checks/zcl_aoc_check_104.clas.abap
+++ b/src/checks/zcl_aoc_check_104.clas.abap
@@ -13,6 +13,14 @@ CLASS zcl_aoc_check_104 DEFINITION
 
   PRIVATE SECTION.
     DATA mo_system TYPE REF TO zif_aoc_system.
+
+    METHODS is_destination_in_rfc_call
+      IMPORTING
+        io_scan          TYPE REF TO zcl_aoc_scan
+        is_statement     TYPE sstmnt
+        iv_token_index   TYPE syst_tabix
+      RETURNING
+        VALUE(rv_result) TYPE abap_bool.
 ENDCLASS.
 
 
@@ -42,38 +50,66 @@ CLASS zcl_aoc_check_104 IMPLEMENTATION.
            FROM <ls_statement>-from TO <ls_statement>-to
            WHERE str = zcl_aoc_scan=>gc_keyword-destination.
 
-        TRY.
-            IF io_scan->tokens[ <ls_statement>-from ]-str = zcl_aoc_scan=>gc_keyword-call
-                AND io_scan->tokens[ <ls_statement>-from + 1 ]-str = zcl_aoc_scan=>gc_keyword-function.
+        DATA(lv_token_index) = sy-tabix.
 
-              ASSIGN io_scan->tokens[ <ls_statement>-from + 2 ] TO FIELD-SYMBOL(<ls_token_function_name>).
+        IF is_destination_in_rfc_call( io_scan        = io_scan
+                                       is_statement   = <ls_statement>
+                                       iv_token_index = lv_token_index ) = abap_false.
+          CONTINUE.
+        ENDIF.
 
-              DATA(lv_function_module_name_length) = strlen( <ls_token_function_name>-str ) - 2.
-              DATA(lv_function_module_name) = <ls_token_function_name>-str+1(lv_function_module_name_length).
+        ASSIGN io_scan->tokens[ <ls_statement>-from + 2 ] TO FIELD-SYMBOL(<ls_token_function_name>).
 
-              DATA(lv_error_code) = VALUE sci_errc( ).
+        DATA(lv_function_module_name_length) = strlen( <ls_token_function_name>-str ) - 2.
+        DATA(lv_function_module_name) = <ls_token_function_name>-str+1(lv_function_module_name_length).
 
-              IF mo_system->is_function_module_existing( CONV #( lv_function_module_name ) ) = abap_false.
-                lv_error_code = gc_code-function_module_does_not_exist.
-              ELSEIF mo_system->is_function_module_rfc_enabled( CONV #( lv_function_module_name ) ) = abap_false.
-                lv_error_code = gc_code-rfc_not_enabled.
-              ELSE.
-                CONTINUE.
-              ENDIF.
+        DATA(lv_error_code) = VALUE sci_errc( ).
 
-              DATA(lv_include) = io_scan->get_include( <ls_statement>-level ).
+        IF mo_system->is_function_module_existing( CONV #( lv_function_module_name ) ) = abap_false.
+          lv_error_code = gc_code-function_module_does_not_exist.
+        ELSEIF mo_system->is_function_module_rfc_enabled( CONV #( lv_function_module_name ) ) = abap_false.
+          lv_error_code = gc_code-rfc_not_enabled.
+        ELSE.
+          CONTINUE.
+        ENDIF.
 
-              inform( p_sub_obj_name = lv_include
-                      p_line         = <ls_token_function_name>-row
-                      p_kind         = mv_errty
-                      p_test         = myname
-                      p_code         = lv_error_code ).
-            ENDIF.
-          CATCH cx_sy_itab_line_not_found.
-            " Does not match function module call syntax, ignore
-            CONTINUE.
-        ENDTRY.
+        DATA(lv_include) = io_scan->get_include( <ls_statement>-level ).
+
+        inform( p_sub_obj_name = lv_include
+                p_line         = <ls_token_function_name>-row
+                p_kind         = mv_errty
+                p_test         = myname
+                p_code         = lv_error_code ).
       ENDLOOP.
     ENDLOOP.
+  ENDMETHOD.
+
+
+  METHOD is_destination_in_rfc_call.
+    TRY.
+        IF io_scan->tokens[ is_statement-from ]-str <> zcl_aoc_scan=>gc_keyword-call
+           OR io_scan->tokens[ is_statement-from + 1 ]-str <> zcl_aoc_scan=>gc_keyword-function.
+          " The token is not in a CALL FUNCTION statement
+          RETURN.
+        ENDIF.
+
+        " DESTINATION is expected to be the 4th token.
+        " But if the addition STARTING NEW TASK is used, then it can be the 8th token
+        IF iv_token_index <> is_statement-from + 3.
+          IF iv_token_index <> is_statement-from + 7.
+            RETURN.
+          ENDIF.
+
+          IF io_scan->tokens[ is_statement-from + 3 ]-str = zcl_aoc_scan=>gc_keyword-starting.
+            " The token is not the DESTINATION keyword
+            RETURN.
+          ENDIF.
+        ENDIF.
+      CATCH cx_sy_itab_line_not_found.
+        RETURN.
+    ENDTRY.
+
+    " All previous checks have passed
+    rv_result = abap_true.
   ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_104.clas.abap
+++ b/src/checks/zcl_aoc_check_104.clas.abap
@@ -100,7 +100,7 @@ CLASS zcl_aoc_check_104 IMPLEMENTATION.
             RETURN.
           ENDIF.
 
-          IF io_scan->tokens[ is_statement-from + 3 ]-str = zcl_aoc_scan=>gc_keyword-starting.
+          IF io_scan->tokens[ is_statement-from + 3 ]-str <> zcl_aoc_scan=>gc_keyword-starting.
             " The token is not the DESTINATION keyword
             RETURN.
           ENDIF.

--- a/src/checks/zcl_aoc_check_104.clas.abap
+++ b/src/checks/zcl_aoc_check_104.clas.abap
@@ -88,7 +88,7 @@ CLASS zcl_aoc_check_104 IMPLEMENTATION.
   METHOD is_destination_in_rfc_call.
     TRY.
         IF io_scan->tokens[ is_statement-from ]-str <> zcl_aoc_scan=>gc_keyword-call
-           OR io_scan->tokens[ is_statement-from + 1 ]-str <> zcl_aoc_scan=>gc_keyword-function.
+            OR io_scan->tokens[ is_statement-from + 1 ]-str <> zcl_aoc_scan=>gc_keyword-function.
           " The token is not in a CALL FUNCTION statement
           RETURN.
         ENDIF.

--- a/src/checks/zcl_aoc_check_104.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_104.clas.testclasses.abap
@@ -164,7 +164,8 @@ CLASS ltcl_test IMPLEMENTATION.
 
   METHOD not_confused_with_parameter_2.
     " Given: The second parameter is named destination, but the function is not called via RFC
-    INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' EXPORTING a = 'A' destination = 'A'.| INTO TABLE mt_code.
+    INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' EXPORTING a = 'A' destination = 'A'.|
+           INTO TABLE mt_code.
 
     " When
     execute_check( ).

--- a/src/checks/zcl_aoc_check_104.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_104.clas.testclasses.abap
@@ -70,8 +70,9 @@ CLASS ltcl_test DEFINITION
     METHODS not_existing_function FOR TESTING.
     METHODS without_destination FOR TESTING.
     METHODS existing_function_rfc_disabled FOR TESTING RAISING cx_static_check.
-    METHODS not_confused_with_parameter FOR TESTING RAISING cx_static_check.
-    METHODS not_confused_with_variable FOR TESTING RAISING cx_static_check.
+    METHODS not_confused_with_parameter_1 FOR TESTING RAISING cx_static_check.
+    METHODS not_confused_with_parameter_2 FOR TESTING RAISING cx_static_check.
+    METHODS not_confused_with_task_name FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 
@@ -150,8 +151,8 @@ CLASS ltcl_test IMPLEMENTATION.
     assert_no_error_code( ).
   ENDMETHOD.
 
-  METHOD not_confused_with_parameter.
-    " Given: A parameter is named destination, but the function is not called via RFC
+  METHOD not_confused_with_parameter_1.
+    " Given: The first parameter is named destination, but the function is not called via RFC
     INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' EXPORTING destination = 'A'.| INTO TABLE mt_code.
 
     " When
@@ -161,7 +162,19 @@ CLASS ltcl_test IMPLEMENTATION.
     assert_no_error_code( ).
   ENDMETHOD.
 
-  METHOD not_confused_with_variable.
+  METHOD not_confused_with_parameter_2.
+    " Given: The second parameter is named destination, but the function is not called via RFC
+    INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' EXPORTING a = 'A' destination = 'A'.| INTO TABLE mt_code.
+
+    " When
+    execute_check( ).
+
+    " Then
+    assert_no_error_code( ).
+  ENDMETHOD.
+
+
+  METHOD not_confused_with_task_name.
     " Given: A task is named destination, but the function is not called via RFC (far-fetched, but possible)
     INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' STARTING NEW TASK destination.| INTO TABLE mt_code.
 

--- a/src/checks/zcl_aoc_check_104.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_104.clas.testclasses.abap
@@ -70,6 +70,8 @@ CLASS ltcl_test DEFINITION
     METHODS not_existing_function FOR TESTING.
     METHODS without_destination FOR TESTING.
     METHODS existing_function_rfc_disabled FOR TESTING RAISING cx_static_check.
+    METHODS not_confused_with_parameter FOR TESTING RAISING cx_static_check.
+    METHODS not_confused_with_variable FOR TESTING RAISING cx_static_check.
 ENDCLASS.
 
 
@@ -145,6 +147,28 @@ CLASS ltcl_test IMPLEMENTATION.
     execute_check( ).
 
     " Then: We don't care if DESTINATION was not used
+    assert_no_error_code( ).
+  ENDMETHOD.
+
+  METHOD not_confused_with_parameter.
+    " Given: A parameter is named destination, but the function is not called via RFC
+    INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' EXPORTING destination = 'A'.| INTO TABLE mt_code.
+
+    " When
+    execute_check( ).
+
+    " Then
+    assert_no_error_code( ).
+  ENDMETHOD.
+
+  METHOD not_confused_with_variable.
+    " Given: A task is named destination, but the function is not called via RFC (far-fetched, but possible)
+    INSERT |CALL FUNCTION '{ gc_function_modules-not_existing }' STARTING NEW TASK destination.| INTO TABLE mt_code.
+
+    " When
+    execute_check( ).
+
+    " Then
     assert_no_error_code( ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/checks/zcl_aoc_scan.clas.abap
+++ b/src/checks/zcl_aoc_scan.clas.abap
@@ -82,6 +82,7 @@ CLASS zcl_aoc_scan DEFINITION
                  move              TYPE string VALUE 'MOVE',
                  to                TYPE string VALUE 'TO',
                  destination       TYPE string VALUE 'DESTINATION',
+                 starting          TYPE string VALUE 'STARTING',
                END OF gc_keyword.
 
     TYPES:


### PR DESCRIPTION
If a parameter, an exception or a variable is called `destination`, then the function module call was falsely detected as using RFC.