### PR TITLE
Make modification check RFC-compatible

### DIFF
--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -111,12 +111,16 @@ CLASS zcl_aoc_super DEFINITION
     METHODS set_uses_checksum
       IMPORTING
         !iv_enable TYPE abap_bool DEFAULT abap_true.
-
+    METHODS is_active_version_by_sap
+      IMPORTING
+        iv_program_name  TYPE progname
+      RETURNING
+        VALUE(rv_result) TYPE abap_bool.
 ENDCLASS.
 
 
 
-CLASS ZCL_AOC_SUPER IMPLEMENTATION.
+CLASS zcl_aoc_super IMPLEMENTATION.
 
 
   METHOD check.
@@ -493,12 +497,7 @@ CLASS ZCL_AOC_SUPER IMPLEMENTATION.
       ENDIF.
 
       IF cl_enh_badi_def_utility=>is_sap_system( ) = abap_false.
-        SELECT SINGLE cnam FROM reposrc INTO lv_cnam
-          WHERE progname = p_sub_obj_name AND r3state = 'A'.
-        IF sy-subrc = 0
-            AND ( lv_cnam = 'SAP'
-            OR lv_cnam = 'SAP*'
-            OR lv_cnam = 'DDIC' ).
+        IF is_active_version_by_sap( p_sub_obj_name ).
           RETURN.
         ENDIF.
       ENDIF.
@@ -739,4 +738,29 @@ CLASS ZCL_AOC_SUPER IMPLEMENTATION.
     ENDIF.
 
   ENDMETHOD.
+
+  METHOD is_active_version_by_sap.
+    DATA lv_author TYPE cnam.
+
+    CALL FUNCTION 'ZAOC_GET_AUTHOR_OF_ACTIVE_VERS'
+      DESTINATION rfc_destination
+      EXPORTING
+        iv_program_name   = iv_program_name
+      IMPORTING
+        ev_author         = lv_author
+      EXCEPTIONS
+        no_active_version = 1
+        OTHERS            = 2.
+
+    IF sy-subrc <> 0.
+      " Ignore for now
+      RETURN.
+    ENDIF.
+
+    CASE lv_author.
+      WHEN 'SAP' OR 'SAP*' OR 'DDIC'.
+        rv_result = abap_true.
+    ENDCASE.
+  ENDMETHOD.
+
 ENDCLASS.

--- a/src/checks/zcl_aoc_super.clas.abap
+++ b/src/checks/zcl_aoc_super.clas.abap
@@ -496,10 +496,9 @@ CLASS zcl_aoc_super IMPLEMENTATION.
         RETURN. " custom HR infotype includes
       ENDIF.
 
-      IF cl_enh_badi_def_utility=>is_sap_system( ) = abap_false.
-        IF is_active_version_by_sap( p_sub_obj_name ).
-          RETURN.
-        ENDIF.
+      IF cl_enh_badi_def_utility=>is_sap_system( ) = abap_false
+          AND is_active_version_by_sap( p_sub_obj_name ) = abap_true.
+        RETURN.
       ENDIF.
     ENDIF.
 

--- a/src/utils/zaoc_get_author_of_active_versrf.sush.xml
+++ b/src/utils/zaoc_get_author_of_active_versrf.sush.xml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_SUSH" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <HEAD>
+    <NAME>ZAOC_GET_AUTHOR_OF_ACTIVE_VERS</NAME>
+    <TYPE>RF</TYPE>
+    <DISPLAY_NAME>ZAOC_GET_AUTHOR_OF_ACTIVE_VERS</DISPLAY_NAME>
+    <STEXT>Get author of active version</STEXT>
+   </HEAD>
+   <USOBX>
+    <USOBX>
+     <NAME>ZAOC_GET_AUTHOR_OF_ACTIVE_VERS</NAME>
+     <TYPE>RF</TYPE>
+     <OBJECT>S_RFC</OBJECT>
+     <OKFLAG>X</OKFLAG>
+    </USOBX>
+   </USOBX>
+   <USOBX_EXT>
+    <item>
+     <OBJECT>S_RFC</OBJECT>
+     <TTEXT>Authorization Check for RFC Access</TTEXT>
+     <OCLSS>AAAB</OCLSS>
+     <OKFLAG>X</OKFLAG>
+     <PS_POSID>BC-MID-RFC</PS_POSID>
+     <CI_TEXT>Check</CI_TEXT>
+     <CH_TEXT>Check</CH_TEXT>
+     <PR_TEXT>No</PR_TEXT>
+     <EXCEP>3</EXCEP>
+     <EXCEP_TX>Okay</EXCEP_TX>
+     <EXCEP_ICON>@08@</EXCEP_ICON>
+    </item>
+   </USOBX_EXT>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/utils/zaoc_wrapper.fugr.xml
+++ b/src/utils/zaoc_wrapper.fugr.xml
@@ -9,6 +9,42 @@
    </INCLUDES>
    <FUNCTIONS>
     <item>
+     <FUNCNAME>ZAOC_GET_AUTHOR_OF_ACTIVE_VERS</FUNCNAME>
+     <REMOTE_CALL>R</REMOTE_CALL>
+     <SHORT_TEXT>Get author of active version</SHORT_TEXT>
+     <IMPORT>
+      <RSIMP>
+       <PARAMETER>IV_PROGRAM_NAME</PARAMETER>
+       <TYP>PROGNAME</TYP>
+      </RSIMP>
+     </IMPORT>
+     <EXPORT>
+      <RSEXP>
+       <PARAMETER>EV_AUTHOR</PARAMETER>
+       <TYP>CNAM</TYP>
+      </RSEXP>
+     </EXPORT>
+     <EXCEPTION>
+      <RSEXC>
+       <EXCEPTION>NO_ACTIVE_VERSION</EXCEPTION>
+      </RSEXC>
+     </EXCEPTION>
+     <DOCUMENTATION>
+      <RSFDO>
+       <PARAMETER>IV_PROGRAM_NAME</PARAMETER>
+       <KIND>P</KIND>
+      </RSFDO>
+      <RSFDO>
+       <PARAMETER>EV_AUTHOR</PARAMETER>
+       <KIND>P</KIND>
+      </RSFDO>
+      <RSFDO>
+       <PARAMETER>NO_ACTIVE_VERSION</PARAMETER>
+       <KIND>X</KIND>
+      </RSFDO>
+     </DOCUMENTATION>
+    </item>
+    <item>
      <FUNCNAME>ZAOC_IS_FUNCTION_MODULE_RFC</FUNCNAME>
      <REMOTE_CALL>R</REMOTE_CALL>
      <SHORT_TEXT>Is function module RFC enabled?</SHORT_TEXT>

--- a/src/utils/zaoc_wrapper.fugr.zaoc_get_author_of_active_vers.abap
+++ b/src/utils/zaoc_wrapper.fugr.zaoc_get_author_of_active_vers.abap
@@ -10,8 +10,9 @@ FUNCTION zaoc_get_author_of_active_vers.
 *"----------------------------------------------------------------------
   SELECT SINGLE cnam
     FROM reposrc
-    INTO @ev_author
-    WHERE progname = @iv_program_name AND r3state = 'A'.
+    INTO ev_author
+    WHERE progname = iv_program_name
+      AND r3state  = 'A'.
 
   IF sy-subrc <> 0.
     RAISE no_active_version.

--- a/src/utils/zaoc_wrapper.fugr.zaoc_get_author_of_active_vers.abap
+++ b/src/utils/zaoc_wrapper.fugr.zaoc_get_author_of_active_vers.abap
@@ -1,0 +1,19 @@
+FUNCTION zaoc_get_author_of_active_vers.
+*"----------------------------------------------------------------------
+*"*"Local Interface:
+*"  IMPORTING
+*"     VALUE(IV_PROGRAM_NAME) TYPE  PROGNAME
+*"  EXPORTING
+*"     VALUE(EV_AUTHOR) TYPE  CNAM
+*"  EXCEPTIONS
+*"      NO_ACTIVE_VERSION
+*"----------------------------------------------------------------------
+  SELECT SINGLE cnam
+    FROM reposrc
+    INTO @ev_author
+    WHERE progname = @iv_program_name AND r3state = 'A'.
+
+  IF sy-subrc <> 0.
+    RAISE no_active_version.
+  ENDIF.
+ENDFUNCTION.


### PR DESCRIPTION
Fixes #1157 

The method `INFORM` of `ZCL_AOC_SUPER` contains logic to check if an object was modified. This only properly worked within non-RFC checks because direct database selections were used.

I've encapsulated the existing logic into an RFC-enabled function module. 