### PR TITLE
Change ZCX_AOC_RFC_ERROR to an unchecked exception

### DIFF
--- a/src/checks/zcl_aoc_check_104.clas.abap
+++ b/src/checks/zcl_aoc_check_104.clas.abap
@@ -38,9 +38,6 @@ CLASS zcl_aoc_check_104 IMPLEMENTATION.
 
     insert_scimessage( iv_code = gc_code-rfc_not_enabled
                        iv_text = TEXT-002 ).
-
-    insert_scimessage( iv_code = gc_code-rfc_error
-                       iv_text = TEXT-003 ).
   ENDMETHOD.
 
 
@@ -81,8 +78,6 @@ CLASS zcl_aoc_check_104 IMPLEMENTATION.
             ENDIF.
           CATCH zcx_aoc_object_not_found.
             lv_error_code = gc_code-function_module_does_not_exist.
-          CATCH zcx_aoc_rfc_error.
-            lv_error_code = gc_code-rfc_error.
         ENDTRY.
 
         DATA(lv_include) = io_scan->get_include( <ls_statement>-level ).

--- a/src/checks/zcl_aoc_check_104.clas.locals_def.abap
+++ b/src/checks/zcl_aoc_check_104.clas.locals_def.abap
@@ -2,5 +2,4 @@ CONSTANTS:
   BEGIN OF gc_code,
     function_module_does_not_exist TYPE sci_errc VALUE '001',
     rfc_not_enabled                TYPE sci_errc VALUE '002',
-    rfc_error                      TYPE sci_errc VALUE '003',
   END OF gc_code.

--- a/src/checks/zcl_aoc_check_104.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_104.clas.testclasses.abap
@@ -214,10 +214,13 @@ CLASS ltcl_test IMPLEMENTATION.
     INSERT |CALL FUNCTION '{ gc_function_modules-triggers_rfc_error }' DESTINATION 'RFC'.| INTO TABLE mt_code.
 
     " When
-    execute_check( ).
+    TRY.
+        execute_check( ).
+      CATCH zcx_aoc_rfc_error INTO DATA(lo_rfc_exception). "#EC EMPTY_CATCH
+    ENDTRY.
 
     " Then
-    assert_error_code( gc_code-rfc_error ).
+    cl_abap_unit_assert=>assert_bound( lo_rfc_exception ).
   ENDMETHOD.
 
 ENDCLASS.

--- a/src/checks/zcl_aoc_check_105.clas.testclasses.abap
+++ b/src/checks/zcl_aoc_check_105.clas.testclasses.abap
@@ -207,12 +207,16 @@ CLASS ltcl_test IMPLEMENTATION.
 
 
   METHOD handle_rfc_error.
-    cl_abap_unit_assert=>skip( 'Implement this when ZCX_AOC_RFC_ERROR was changed to an unchecked exception' ).
-
     " Given: System mock is set up to raise an RFC error for this function module
     INSERT |CALL FUNCTION '{ gc_function_modules-triggers_rfc_error }' DESTINATION 'RFC'.| INTO TABLE mt_code.
 
     " When
-    execute_check( ).
+    TRY.
+        execute_check( ).
+      CATCH zcx_aoc_rfc_error INTO DATA(lo_rfc_exception). "#EC EMPTY_CATCH
+    ENDTRY.
+
+    " Then
+    cl_abap_unit_assert=>assert_bound( lo_rfc_exception ).
   ENDMETHOD.
 ENDCLASS.

--- a/src/utils/zcx_aoc_rfc_error.clas.abap
+++ b/src/utils/zcx_aoc_rfc_error.clas.abap
@@ -1,7 +1,12 @@
 "! <p class="shorttext synchronized">Raised when RFC error occurs</p>
+"! <p>
+"! This exception inherits from CX_NO_CHECK because we want to cause a runtime error on purpose.
+"! Runtime errors show up as "check failures" in the ATC result to indicate that the check itself was not successful.
+"! It is better to explicitly cause a "check failure" than to mix this with the regular findings.
+"! </p>
 CLASS zcx_aoc_rfc_error DEFINITION
   PUBLIC
-  INHERITING FROM cx_static_check
+  INHERITING FROM cx_no_check
   FINAL
   CREATE PUBLIC.
 

--- a/src/utils/zif_aoc_system.intf.abap
+++ b/src/utils/zif_aoc_system.intf.abap
@@ -7,16 +7,13 @@ INTERFACE zif_aoc_system
     RETURNING
       VALUE(rv_result)        TYPE abap_bool
     RAISING
-      zcx_aoc_object_not_found
-      zcx_aoc_rfc_error.
+      zcx_aoc_object_not_found.
 
   METHODS is_function_module_rfc_blocked
     IMPORTING
       iv_function_module_name TYPE funcname
       iv_blocklist_package    TYPE devclass
     RETURNING
-      VALUE(rv_result)        TYPE abap_bool
-    RAISING
-      zcx_aoc_rfc_error.
+      VALUE(rv_result)        TYPE abap_bool.
 
 ENDINTERFACE.


### PR DESCRIPTION
As announced in #1181, I've changed `ZCX_AOC_RFC_ERROR` to inherit from `CX_NO_CHECK` instead of `CX_STATIC_CHECK`.

Runtime errors show up as "check failures" in the ATC result to indicate that the check itself was not successful. It is better to explicitly cause a "check failure" than to mix this with the regular findings.

Two checks are using this exception. I've adapted them and their unit tests.